### PR TITLE
Remove duplicate code from initializer list

### DIFF
--- a/src/car/distance/DistanceCar.cpp
+++ b/src/car/distance/DistanceCar.cpp
@@ -20,16 +20,6 @@ DistanceCar::DistanceCar(Control& control, Odometer& odometer, Runtime& runtime)
     , mOdometerLeft(odometer)
     , mOdometerRight(odometer)
     , mRuntime(runtime)
-    , mCruiseControlEnabled{ false }
-    , mProportional{ 0 }
-    , mIntegral{ 0 }
-    , mDerivative{ 0 }
-    , mFrequency{ 0 }
-    , mPreviousUpdate{ 0 }
-    , mTargetSpeed{ 0 }
-    , mPreviousControlledSpeed{ 0 }
-    , mIntegratedError{ 0 }
-    , mPreviousError{ 0 }
 {
 }
 
@@ -42,16 +32,6 @@ DistanceCar::DistanceCar(Control& control,
     , mOdometerLeft(odometerLeft)
     , mOdometerRight(odometerRight)
     , mRuntime(runtime)
-    , mCruiseControlEnabled{ false }
-    , mProportional{ 0 }
-    , mIntegral{ 0 }
-    , mDerivative{ 0 }
-    , mFrequency{ 0 }
-    , mPreviousUpdate{ 0 }
-    , mTargetSpeed{ 0 }
-    , mPreviousControlledSpeed{ 0 }
-    , mIntegratedError{ 0 }
-    , mPreviousError{ 0 }
 {
 }
 

--- a/src/car/distance/DistanceCar.hpp
+++ b/src/car/distance/DistanceCar.hpp
@@ -194,16 +194,16 @@ private:
     Odometer& mOdometerLeft;
     Odometer& mOdometerRight;
     Runtime& mRuntime;
-    bool mCruiseControlEnabled;
-    float mProportional;
-    float mIntegral;
-    float mDerivative;
-    unsigned long mFrequency;
-    unsigned long mPreviousUpdate;
-    float mTargetSpeed;
-    float mPreviousControlledSpeed;
-    float mIntegratedError;
-    float mPreviousError;
+    bool mCruiseControlEnabled{ false };
+    float mProportional{ 0 };
+    float mIntegral{ 0 };
+    float mDerivative{ 0 };
+    unsigned long mFrequency{ 0 };
+    unsigned long mPreviousUpdate{ 0 };
+    float mTargetSpeed{ 0 };
+    float mPreviousControlledSpeed{ 0 };
+    float mIntegratedError{ 0 };
+    float mPreviousError{ 0 };
 
     bool areOdometersAttached();
     bool areOdometersDirectional();


### PR DESCRIPTION
## Description
Initialize member variables in the header instead of the initializer list so to avoid code duplication.

## Solved issue(s)
Fixes #17 