### PR TITLE
Refactor and fix errors for compilation with stricter flags

### DIFF
--- a/src/car/distance/DistanceCar.cpp
+++ b/src/car/distance/DistanceCar.cpp
@@ -154,7 +154,7 @@ void DistanceCar::update()
         controlledSpeed = kIdleControlSpeed;
     }
     // Pass the rounded output of the pid as an input to the control
-    SimpleCar::setSpeed(lroundf(controlledSpeed));
+    SimpleCar::setSpeed(roundf(controlledSpeed));
     // Save the unrounded float output of the PID controller
     mPreviousControlledSpeed = controlledSpeed;
 }

--- a/src/control/differential/DifferentialControl.cpp
+++ b/src/control/differential/DifferentialControl.cpp
@@ -29,19 +29,20 @@ void DifferentialControl::setSpeed(int speed)
 void DifferentialControl::setMotors()
 {
     // With differential control, angle represents the ratio of speed between the two motors
-    float ratio = (kMaxControlAngle - getAbsolute(mAngle)) / static_cast<float>(kMaxControlAngle);
+    float ratio = static_cast<float>(kMaxControlAngle - getAbsolute(mAngle))
+                  / static_cast<float>(kMaxControlAngle);
 
     if (mAngle < kIdleControlAngle)
     {
         // Turning to the left (counter clockwise) by setting lower speed to the left motor
-        mLeftMotor.setSpeed(static_cast<int>(mSpeed * ratio));
+        mLeftMotor.setSpeed(static_cast<int>(static_cast<float>(mSpeed) * ratio));
         mRightMotor.setSpeed(mSpeed);
     }
     else
     {
         // Turning to the right (clockwise) by setting lower speed to the right motor
         mLeftMotor.setSpeed(mSpeed);
-        mRightMotor.setSpeed(static_cast<int>(mSpeed * ratio));
+        mRightMotor.setSpeed(static_cast<int>(static_cast<float>(mSpeed) * ratio));
     }
 }
 

--- a/src/sensors/distance/DistanceSensor.hpp
+++ b/src/sensors/distance/DistanceSensor.hpp
@@ -6,6 +6,17 @@
 
 #include <stdint.h>
 
+namespace smartcarlib
+{
+namespace constants
+{
+namespace distanceSensor
+{
+const int kMaxMedianMeasurements = 100;
+}
+} // namespace constants
+} // namespace smartcarlib
+
 class DistanceSensor
 {
 public:
@@ -25,8 +36,9 @@ public:
 
     /**
      * Gets the median distance from the specified number of measurements.
-     * @param  iterations Number of measurements to conduct
-     * @return            The median of the conducted measurements
+     * @param  iterations Number of measurements to conduct (at most `kMaxMedianMeasurements`)
+     * @return            The median of the conducted measurements or an error value
+     *                    if the number of iterations is `0` or larger than `kMaxMedianMeasurements`
      *
      * **Example:**
      * \code

--- a/src/sensors/distance/infrared/analog/InfraredAnalogSensor.cpp
+++ b/src/sensors/distance/infrared/analog/InfraredAnalogSensor.cpp
@@ -18,7 +18,7 @@ unsigned int InfraredAnalogSensor::getMedianDistance(uint8_t iterations)
 {
     if (iterations == 0 || iterations > kMaxMedianMeasurements)
     {
-        return -1; // Return a large number to indicate error
+        return static_cast<unsigned int>(-1); // Return a large number to indicate error
     }
 
     unsigned int measurements[kMaxMedianMeasurements];

--- a/src/sensors/distance/infrared/analog/InfraredAnalogSensor.cpp
+++ b/src/sensors/distance/infrared/analog/InfraredAnalogSensor.cpp
@@ -6,6 +6,7 @@ namespace
 const unsigned long kMedianMeasurementDelay = 15;
 }
 
+using namespace smartcarlib::constants::distanceSensor;
 using namespace smartcarlib::utils;
 
 InfraredAnalogSensor::InfraredAnalogSensor(Runtime& runtime)
@@ -15,12 +16,12 @@ InfraredAnalogSensor::InfraredAnalogSensor(Runtime& runtime)
 
 unsigned int InfraredAnalogSensor::getMedianDistance(uint8_t iterations)
 {
-    if (iterations == 0)
+    if (iterations == 0 || iterations > kMaxMedianMeasurements)
     {
         return -1; // Return a large number to indicate error
     }
 
-    unsigned int measurements[iterations];
+    unsigned int measurements[kMaxMedianMeasurements];
     for (auto i = 0; i < iterations; i++)
     {
         measurements[i] = getDistance();

--- a/src/sensors/distance/infrared/analog/sharp/GP2D120.cpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2D120.cpp
@@ -16,7 +16,7 @@ GP2D120::GP2D120(uint8_t pin, Runtime& runtime)
 unsigned int GP2D120::getDistance()
 {
     auto analogReading = mRuntime.getAnalogPinState(kPin);
-    auto result        = ((2914 / (analogReading + 5)) - 1);
+    auto result        = static_cast<unsigned int>((2914 / (analogReading + 5)) - 1);
 
     return (result >= kMinDistance && result <= kMaxDistance ? result : 0);
 }

--- a/src/sensors/distance/infrared/analog/sharp/GP2Y0A02.cpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2Y0A02.cpp
@@ -16,7 +16,7 @@ GP2Y0A02::GP2Y0A02(uint8_t pin, Runtime& runtime)
 unsigned int GP2Y0A02::getDistance()
 {
     auto analogReading = mRuntime.getAnalogPinState(kPin);
-    auto result        = 9462 / (analogReading - 16.92);
+    auto result        = static_cast<unsigned int>(9462 / (analogReading - 16.92));
 
     return (result >= kMinDistance && result <= kMaxDistance ? result : 0);
 }

--- a/src/sensors/distance/infrared/analog/sharp/GP2Y0A21.cpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2Y0A21.cpp
@@ -17,7 +17,7 @@ unsigned int GP2Y0A21::getDistance()
 {
     auto analogReading = mRuntime.getAnalogPinState(kPin);
     // Formula source: Jeroen Doggen http://plat.is/v3x25
-    auto result = (1 / (0.0002391473 * analogReading - 0.0100251467));
+    auto result = static_cast<unsigned int>(1 / (0.0002391473 * analogReading - 0.0100251467));
 
-    return (result >= kMinDistance && result <= kMaxDistance ? result : 0);
+    return (result >= kMinDistance) && (result <= kMaxDistance) ? result : 0;
 }

--- a/src/sensors/distance/ultrasound/i2c/SRF08.cpp
+++ b/src/sensors/distance/ultrasound/i2c/SRF08.cpp
@@ -123,7 +123,8 @@ uint8_t SRF08::getLightReading()
     mRuntime.i2cRequestFrom(mAddress, kNumberOfBytesToRequest);
     mRuntime.delayMillis(mPingDelay);
 
-    return mRuntime.i2cAvailable() ? mRuntime.i2cRead() : -1;
+    return mRuntime.i2cAvailable() ? static_cast<uint8_t>(mRuntime.i2cRead())
+                                   : static_cast<uint8_t>(-1);
 }
 
 uint8_t SRF08::changeAddress(uint8_t newAddress)
@@ -153,7 +154,7 @@ uint8_t SRF08::changeAddress(uint8_t newAddress)
 
     mRuntime.i2cBeginTransmission(mAddress);
     mRuntime.i2cWrite(kRangingCommandRegister);
-    mRuntime.i2cWrite(newAddress << 1);
+    mRuntime.i2cWrite(static_cast<uint8_t>(newAddress << 0x01));
     mRuntime.i2cEndTransmission();
 
     mAddress = newAddress;

--- a/src/sensors/distance/ultrasound/i2c/SRF08.cpp
+++ b/src/sensors/distance/ultrasound/i2c/SRF08.cpp
@@ -48,19 +48,19 @@ unsigned int SRF08::getDistance()
     mRuntime.i2cRequestFrom(mAddress, kNumberOfBytesToRequest);
     if (!mRuntime.i2cAvailable())
     {
-        return -1; // Return a large error-like value
+        return static_cast<unsigned int>(-1); // Return a large error-like value
     }
     auto high = mRuntime.i2cRead();
     auto low  = mRuntime.i2cRead();
 
-    return static_cast<int16_t>((high << 8) + low);
+    return static_cast<uint16_t>((high << 8) + low);
 }
 
 unsigned int SRF08::getMedianDistance(uint8_t iterations)
 {
     if (iterations == 0 || iterations > kMaxMedianMeasurements)
     {
-        return -1; // Return a large number to indicate error
+        return static_cast<unsigned int>(-1); // Return a large number to indicate error
     }
 
     unsigned int measurements[kMaxMedianMeasurements];

--- a/src/sensors/distance/ultrasound/i2c/SRF08.cpp
+++ b/src/sensors/distance/ultrasound/i2c/SRF08.cpp
@@ -12,6 +12,7 @@ const uint8_t kRangingInCm            = 0x51;
 } // namespace
 
 using namespace smartcarlib::constants::srf08;
+using namespace smartcarlib::constants::distanceSensor;
 using namespace smartcarlib::utils;
 
 SRF08::SRF08(uint8_t address, Runtime& runtime)
@@ -57,12 +58,12 @@ unsigned int SRF08::getDistance()
 
 unsigned int SRF08::getMedianDistance(uint8_t iterations)
 {
-    if (iterations == 0)
+    if (iterations == 0 || iterations > kMaxMedianMeasurements)
     {
         return -1; // Return a large number to indicate error
     }
 
-    unsigned int measurements[iterations];
+    unsigned int measurements[kMaxMedianMeasurements];
     for (auto i = 0; i < iterations; i++)
     {
         measurements[i] = getDistance();

--- a/src/sensors/distance/ultrasound/ping/SR04.cpp
+++ b/src/sensors/distance/ultrasound/ping/SR04.cpp
@@ -2,8 +2,8 @@
 #include "../../../../utilities/Utilities.hpp"
 namespace
 {
-const float kTimeToTravelOneCmAndBack   = 29.15 * 2; // In microseconds
-const unsigned long kTimeToMeasureOneCm = 120;       // Empirically determined
+const float kTimeToTravelOneCmAndBack   = 29.15f * 2.0f; // In microseconds
+const unsigned long kTimeToMeasureOneCm = 120;           // Empirically determined
 // We should wait long enough between two consecutive measurements
 // so to avoid getting parasitic readings from old returning waves.
 const unsigned long kMedianMeasurementDelay = 15; // In milliseconds
@@ -50,7 +50,8 @@ unsigned int SR04::getDistance()
     // Wait for the pulse to arrive and measure its duration
     auto duration = mRuntime.getPulseDuration(kEchoPin, kHigh, kTimeout);
     // Calculate how much far out the object is
-    unsigned int calculatedDistance = duration / kTimeToTravelOneCmAndBack;
+    unsigned int calculatedDistance
+        = static_cast<unsigned int>(static_cast<float>(duration) / kTimeToTravelOneCmAndBack);
 
     return calculatedDistance <= kMaxDistance ? calculatedDistance : kError;
 }

--- a/src/sensors/distance/ultrasound/ping/SR04.cpp
+++ b/src/sensors/distance/ultrasound/ping/SR04.cpp
@@ -10,6 +10,7 @@ const unsigned long kMedianMeasurementDelay = 15; // In milliseconds
 } // namespace
 
 using namespace smartcarlib::constants::sr04;
+using namespace smartcarlib::constants::distanceSensor;
 using namespace smartcarlib::utils;
 
 SR04::SR04(uint8_t triggerPin, uint8_t echoPin, unsigned int maxDistance, Runtime& runtime)
@@ -56,12 +57,12 @@ unsigned int SR04::getDistance()
 
 unsigned int SR04::getMedianDistance(uint8_t iterations)
 {
-    if (iterations == 0)
+    if (iterations == 0 || iterations > kMaxMedianMeasurements)
     {
         return kError;
     }
 
-    unsigned int measurements[iterations];
+    unsigned int measurements[kMaxMedianMeasurements];
     for (auto i = 0; i < iterations; i++)
     {
         measurements[i] = getDistance();

--- a/src/sensors/heading/gyroscope/GY50.cpp
+++ b/src/sensors/heading/gyroscope/GY50.cpp
@@ -48,8 +48,8 @@ void GY50::update()
 
     if (getAbsolute(drift) > kGyroThreshold)
     {
-        float gyroRate = drift * kGyroSensitivity;
-        mAngularDisplacement += gyroRate / (1000.0 / interval);
+        float gyroRate = static_cast<float>(drift) * kGyroSensitivity;
+        mAngularDisplacement += gyroRate / (1000.0f / static_cast<float>(interval));
     }
     mPreviousSample = currentTime;
 }
@@ -98,7 +98,7 @@ int GY50::getOffset(int measurements)
         mRuntime.delayMillis(kMeasurementInterval);
     }
 
-    return sum / measurements;
+    return static_cast<int>(sum / measurements);
 }
 
 int GY50::getAngularVelocity()

--- a/src/sensors/odometer/Odometer.hpp
+++ b/src/sensors/odometer/Odometer.hpp
@@ -26,6 +26,8 @@ const unsigned long kMinimumPulseGap       = 700;
 class Odometer
 {
 public:
+    virtual ~Odometer() = default;
+
     /**
      * Returns the travelled distance in centimeters where sign can indicate
      * direction if there is hardware support

--- a/src/sensors/odometer/interrupt/DirectionalOdometer.cpp
+++ b/src/sensors/odometer/interrupt/DirectionalOdometer.cpp
@@ -70,7 +70,8 @@ void STORED_IN_RAM DirectionalOdometer::update()
 
 long DirectionalOdometer::getDistance()
 {
-    return DirectionlessOdometer::getDistance() - (mNegativePulsesCounter / mPulsesPerMeterRatio);
+    return DirectionlessOdometer::getDistance()
+           - static_cast<long>(static_cast<float>(mNegativePulsesCounter) / mPulsesPerMeterRatio);
 }
 
 float DirectionalOdometer::getSpeed()

--- a/src/sensors/odometer/interrupt/DirectionlessOdometer.cpp
+++ b/src/sensors/odometer/interrupt/DirectionlessOdometer.cpp
@@ -24,8 +24,9 @@ DirectionlessOdometer::DirectionlessOdometer(uint8_t pulsePin,
     , kSensorAttached{ mRuntime.pinToInterrupt(pulsePin) != kNotAnInterrupt }
 {
     mRuntime.setPinDirection(pulsePin, mRuntime.getInputState());
-    mRuntime.setInterrupt(
-        mRuntime.pinToInterrupt(pulsePin), callback, mRuntime.getRisingEdgeMode());
+    mRuntime.setInterrupt(static_cast<uint8_t>(mRuntime.pinToInterrupt(pulsePin)),
+                          callback,
+                          mRuntime.getRisingEdgeMode());
 }
 
 long DirectionlessOdometer::getDistance()

--- a/src/sensors/odometer/interrupt/DirectionlessOdometer.cpp
+++ b/src/sensors/odometer/interrupt/DirectionlessOdometer.cpp
@@ -15,12 +15,11 @@ DirectionlessOdometer::DirectionlessOdometer(uint8_t pulsePin,
                                              InterruptCallback callback,
                                              unsigned long pulsesPerMeter,
                                              Runtime& runtime)
-    : mPulsesPerMeterRatio{ pulsesPerMeter > 0 ? pulsesPerMeter / 100.0f
+    : mPulsesPerMeterRatio{ pulsesPerMeter > 0 ? static_cast<float>(pulsesPerMeter) / 100.0f
                                                : kDefaultPulsesPerMeter / 100.0f }
-    , mMillimetersPerPulse{ pulsesPerMeter > 0 ? static_cast<unsigned long>(
-                                lroundf(kMillimetersInMeter / pulsesPerMeter))
-                                               : static_cast<unsigned long>(lroundf(
-                                                   kMillimetersInMeter / kDefaultPulsesPerMeter)) }
+    , mMillimetersPerPulse{ pulsesPerMeter > 0
+                                ? kMillimetersInMeter / static_cast<float>(pulsesPerMeter)
+                                : kMillimetersInMeter / static_cast<float>(kDefaultPulsesPerMeter) }
     , mRuntime(runtime)
     , kSensorAttached{ mRuntime.pinToInterrupt(pulsePin) != kNotAnInterrupt }
 {
@@ -31,14 +30,14 @@ DirectionlessOdometer::DirectionlessOdometer(uint8_t pulsePin,
 
 long DirectionlessOdometer::getDistance()
 {
-    return mPulsesCounter / mPulsesPerMeterRatio;
+    return static_cast<long>(static_cast<float>(mPulsesCounter) / mPulsesPerMeterRatio);
 }
 
 float DirectionlessOdometer::getSpeed()
 {
     // To get the current speed in m/sec, divide the meters per pulse (dx) with
     // the length between the last two pulses (dt)
-    return mDt > 0 ? kMillisecondsInSecond * mMillimetersPerPulse / mDt : 0;
+    return mDt > 0 ? kMillisecondsInSecond * mMillimetersPerPulse / static_cast<float>(mDt) : 0.0f;
 }
 
 bool DirectionlessOdometer::isAttached() const

--- a/src/sensors/odometer/interrupt/DirectionlessOdometer.hpp
+++ b/src/sensors/odometer/interrupt/DirectionlessOdometer.hpp
@@ -82,7 +82,7 @@ protected:
     volatile unsigned long mDt{ 0 };
 
 private:
-    const unsigned long mMillimetersPerPulse;
+    const float mMillimetersPerPulse;
     Runtime& mRuntime;
     const bool kSensorAttached;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,27 @@ project(Smartcar_Tests)
 set(REPOSITORY_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/ut)
 set(SMARTCAR_LIB ${REPOSITORY_ROOT}/src)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+    -std=c++14 \
+    -Wcast-align \
+    -Wpedantic \
+    -Wcast-qual \
+    -Wconversion \
+    -Wdisabled-optimization \
+    -Winit-self \
+    -Wnon-virtual-dtor \
+    -Wold-style-cast \
+    -Woverloaded-virtual \
+    -Wparentheses \
+    -Wredundant-decls \
+    -Wshadow \
+    -Wsign-promo \
+    -Wstrict-aliasing \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -pthread \
+")
 
 # Coverage
 list(APPEND CMAKE_MODULE_PATH ${REPOSITORY_ROOT}/CmakeModules)

--- a/test/ut/DifferentialControl_test.cpp
+++ b/test/ut/DifferentialControl_test.cpp
@@ -72,7 +72,7 @@ TEST_F(DifferentialControlSpeedTest, setAngle_WhenIdleAngle_WillSetSameSpeedToMo
 TEST_F(DifferentialControlSpeedTest, setAngle_WhenValidAngle_WillSetCorrectSpeedToMotors)
 {
     EXPECT_CALL(mLeftMotor, setSpeed(kSpeed));
-    EXPECT_CALL(mRightMotor, setSpeed(kSpeed * 2 / 3.0f));
+    EXPECT_CALL(mRightMotor, setSpeed((kSpeed * 2) / 3));
 
     mDifferentialControl.setAngle(kMaxControlAngle / 3);
 }
@@ -122,7 +122,8 @@ TEST_F(DifferentialControlBasicTest, setSpeed_WhenAngleSet_WillSetCorrectSpeedTo
     mDifferentialControl.setSpeed(kMaxMotorSpeed);
 }
 
-TEST_F(DifferentialControlBasicTest, overrideMotorSpeed_WhenSpeedOutOfRange_WillSetCorrectSpeedToMotors)
+TEST_F(DifferentialControlBasicTest,
+       overrideMotorSpeed_WhenSpeedOutOfRange_WillSetCorrectSpeedToMotors)
 {
     EXPECT_CALL(mLeftMotor, setSpeed(kMinMotorSpeed));
     EXPECT_CALL(mRightMotor, setSpeed(kMaxMotorSpeed));
@@ -132,7 +133,7 @@ TEST_F(DifferentialControlBasicTest, overrideMotorSpeed_WhenSpeedOutOfRange_Will
 
 TEST_F(DifferentialControlBasicTest, overrideMotorSpeed_WhenValidSpeed_WillSetSpeedToMotors)
 {
-    int expectedLeftMotorSpeed = kMaxMotorSpeed / 2;
+    int expectedLeftMotorSpeed  = kMaxMotorSpeed / 2;
     int expectedRightMotorSpeed = kMinMotorSpeed / 2;
     EXPECT_CALL(mLeftMotor, setSpeed(expectedLeftMotorSpeed));
     EXPECT_CALL(mRightMotor, setSpeed(expectedRightMotorSpeed));

--- a/test/ut/DirectionalOdometer_test.cpp
+++ b/test/ut/DirectionalOdometer_test.cpp
@@ -9,8 +9,6 @@ using namespace smartcarlib::constants::odometer;
 
 namespace
 {
-const uint8_t kInput               = 0;
-const int8_t kAnInterrupt          = 1;
 const uint8_t kDirectionPin        = 5;
 const uint8_t kPinStateWhenForward = 102;
 const int8_t kNotAnInterrupt       = -1;

--- a/test/ut/DirectionlessOdometer_test.cpp
+++ b/test/ut/DirectionlessOdometer_test.cpp
@@ -12,8 +12,6 @@ namespace
 {
 const int8_t kNotAnInterrupt = -1;
 const int8_t kAnInterrupt    = 1;
-const uint8_t kRisingEdge    = 3;
-const uint8_t kInput         = 0;
 const uint8_t kPin           = 23;
 const auto kDummyCallback    = []() {};
 

--- a/test/ut/DistanceCar_test.cpp
+++ b/test/ut/DistanceCar_test.cpp
@@ -59,11 +59,6 @@ public:
 class DistanceCarCruiseControlTest : public DistanceCarTest
 {
 public:
-    DistanceCarCruiseControlTest()
-        : mNumberOfCurrentTimeMillisCalls{ 0 }
-    {
-    }
-
     virtual void SetUp()
     {
         auto validCallTimer
@@ -75,7 +70,7 @@ public:
         mDistanceCar.enableCruiseControl();
     }
 
-    int mNumberOfCurrentTimeMillisCalls;
+    unsigned long mNumberOfCurrentTimeMillisCalls{ 0 };
 };
 
 TEST_F(DistanceCarTest, getDistance_WhenOdometersNotAttached_WillReturnError)
@@ -159,7 +154,7 @@ TEST_F(DistanceCarOdometersAttachedTest, setSpeed_WhenDirectionChangesInCruiseCo
     // and will eventually set the speed to idle
     EXPECT_CALL(mOdometerLeft, getDistance()).Times(AtLeast(2));
     EXPECT_CALL(mOdometerRight, getDistance()).Times(AtLeast(2));
-    EXPECT_CALL(mControl, setSpeed(static_cast<float>(kIdleControlSpeed))).Times(AtLeast(1));
+    EXPECT_CALL(mControl, setSpeed(kIdleControlSpeed)).Times(AtLeast(1));
 
     mDistanceCar.setSpeed(-initialSpeed / 2.0f);
 }
@@ -169,7 +164,7 @@ TEST_F(DistanceCarOdometersAttachedTest, setSpeed_WhenNotMoving_WillNotBrake)
     // Speed might be set to idle but without sampling the dX or other attempts to stop the car
     EXPECT_CALL(mOdometerLeft, getDistance()).Times(0);
     EXPECT_CALL(mOdometerRight, getDistance()).Times(0);
-    EXPECT_CALL(mControl, setSpeed(static_cast<float>(kIdleControlSpeed))).Times(AtMost(1));
+    EXPECT_CALL(mControl, setSpeed(kIdleControlSpeed)).Times(AtMost(1));
 
     mDistanceCar.setSpeed(static_cast<float>(kIdleControlSpeed));
 }

--- a/test/ut/DistanceCar_test.cpp
+++ b/test/ut/DistanceCar_test.cpp
@@ -113,7 +113,7 @@ TEST_F(DistanceCarTest, getDistance_WhenOneOdometerAttached_WillReturnItsDistanc
 
 TEST_F(DistanceCarTest, setSpeed_WhenNotAttached_WillNotConsiderCruiseControlAndSetOnlySpeed)
 {
-    float speed = 50.0;
+    const int speed = 50;
 
     EXPECT_CALL(mOdometerLeft, isAttached()).Times(AtMost(1)).WillOnce(Return(false));
     EXPECT_CALL(mOdometerRight, isAttached()).Times(AtMost(1)).WillOnce(Return(false));
@@ -141,18 +141,18 @@ TEST_F(
 
 TEST_F(DistanceCarOdometersAttachedTest, setSpeed_WhenCarShouldStop_WillBrake)
 {
-    auto initialSpeed = 50.0;
+    auto initialSpeed = 50.0f;
     mDistanceCar.setSpeed(initialSpeed);
 
-    EXPECT_CALL(mControl, setSpeed(-initialSpeed / kBreakSpeedScale));
-    EXPECT_CALL(mControl, setSpeed(static_cast<float>(kIdleControlSpeed)));
+    EXPECT_CALL(mControl, setSpeed(static_cast<int>(-initialSpeed) / kBreakSpeedScale));
+    EXPECT_CALL(mControl, setSpeed(kIdleControlSpeed));
 
-    mDistanceCar.setSpeed(static_cast<float>(kIdleControlSpeed));
+    mDistanceCar.setSpeed(kIdleControlSpeed);
 }
 
 TEST_F(DistanceCarOdometersAttachedTest, setSpeed_WhenDirectionChangesInCruiseControl_WillBrake)
 {
-    auto initialSpeed = 50.0;
+    auto initialSpeed = 50.0f;
     mDistanceCar.enableCruiseControl();
     mDistanceCar.setSpeed(initialSpeed);
     // When braking we will sample the distance at least two times (to determine a dX)
@@ -161,7 +161,7 @@ TEST_F(DistanceCarOdometersAttachedTest, setSpeed_WhenDirectionChangesInCruiseCo
     EXPECT_CALL(mOdometerRight, getDistance()).Times(AtLeast(2));
     EXPECT_CALL(mControl, setSpeed(static_cast<float>(kIdleControlSpeed))).Times(AtLeast(1));
 
-    mDistanceCar.setSpeed(-initialSpeed / 2);
+    mDistanceCar.setSpeed(-initialSpeed / 2.0f);
 }
 
 TEST_F(DistanceCarOdometersAttachedTest, setSpeed_WhenNotMoving_WillNotBrake)
@@ -177,7 +177,7 @@ TEST_F(DistanceCarOdometersAttachedTest, setSpeed_WhenNotMoving_WillNotBrake)
 TEST_F(DistanceCarOdometersAttachedTest,
        setSpeed_WhenCruiseControlAndNoBrake_WillSetSpeedInPidController)
 {
-    auto speed = -30.0;
+    auto speed = -30.0f;
     // Speed should be set via the PID controller algorithm and not directly here
     EXPECT_CALL(mControl, setSpeed(_)).Times(0);
 
@@ -187,8 +187,8 @@ TEST_F(DistanceCarOdometersAttachedTest,
 
 TEST_F(DistanceCarOdometersAttachedTest, setSpeed_WhenNoCruiseControlAndNoBrake_WillSetSpeed)
 {
-    auto speed = 10.0;
-    EXPECT_CALL(mControl, setSpeed(speed));
+    auto speed = 10.0f;
+    EXPECT_CALL(mControl, setSpeed(static_cast<int>(speed)));
 
     mDistanceCar.setSpeed(speed);
 }
@@ -203,8 +203,8 @@ TEST_F(DistanceCarTest, getSpeed_WhenOdometersNotAttaached_WillReturnError)
 
 TEST_F(DistanceCarOdometersAttachedTest, getSpeed_WhenOdometersAttached_WillReturnAverageSpeed)
 {
-    float leftSpeed    = 2.1;
-    float rightSpeed   = 1.8;
+    float leftSpeed    = 2.1f;
+    float rightSpeed   = 1.8f;
     auto expectedSpeed = (leftSpeed + rightSpeed) / 2;
     EXPECT_CALL(mOdometerLeft, getSpeed()).WillOnce(Return(leftSpeed));
     EXPECT_CALL(mOdometerRight, getSpeed()).WillOnce(Return(rightSpeed));
@@ -317,7 +317,7 @@ TEST_F(DistanceCarCruiseControlTest,
        update_WhenGroundSpeedAboveTargetAndOdometersAreDirectionless_WillSetIdleSpeed)
 {
     float targetSpeed = 10;
-    float groundSpeed = targetSpeed * 1.1;
+    float groundSpeed = targetSpeed * 1.1f;
 
     ON_CALL(mOdometerLeft, getSpeed()).WillByDefault(Return(groundSpeed));
     ON_CALL(mOdometerRight, getSpeed()).WillByDefault(Return(groundSpeed));
@@ -339,7 +339,7 @@ TEST_F(DistanceCarCruiseControlTest,
        update_WhenGroundSpeedAboveTargetAndOdometersAreDirectional_WillDecreaseSpeedToMotors)
 {
     float targetSpeed = 6.5;
-    float groundSpeed = targetSpeed * 1.1;
+    float groundSpeed = targetSpeed * 1.1f;
 
     ON_CALL(mOdometerLeft, providesDirection()).WillByDefault(Return(true));
     ON_CALL(mOdometerRight, providesDirection()).WillByDefault(Return(true));
@@ -362,7 +362,7 @@ TEST_F(DistanceCarCruiseControlTest,
        update_WhenBackwardSpeedBelowTarget_WillIncreaseMotorSpeedBackward)
 {
     float targetSpeed = -3.5;
-    float groundSpeed = abs(targetSpeed * 0.9); // Directionless odometers return unsigned speed
+    float groundSpeed = abs(targetSpeed * 0.9f); // Directionless odometers return unsigned speed
 
     ON_CALL(mOdometerLeft, getSpeed()).WillByDefault(Return(groundSpeed));
     ON_CALL(mOdometerRight, getSpeed()).WillByDefault(Return(groundSpeed));

--- a/test/ut/GY50_test.cpp
+++ b/test/ut/GY50_test.cpp
@@ -136,9 +136,9 @@ TEST_F(GY50AttachedTest, getHeading_WhenAngularVelocityRead_WillReturnCorrectDis
 
 TEST_F(GY50AttachedTest, getHeading_WhenAngularVelocityReadOverTime_WillReturnCorrectDistance)
 {
-    const int step       = kInterval + 1;
-    int currentIteration = 0;
-    auto timer           = [&step, &currentIteration]() { return ++currentIteration * step; };
+    const unsigned long step       = kInterval + 1;
+    unsigned long currentIteration = 0;
+    auto timer = [&step, &currentIteration]() { return ++currentIteration * step; };
     ON_CALL(mRuntime, currentTimeMillis()).WillByDefault(InvokeWithoutArgs(timer));
     ON_CALL(mRuntime, i2cAvailable()).WillByDefault(Return(1));
     EXPECT_CALL(mRuntime, i2cRead())
@@ -159,8 +159,8 @@ TEST_F(GY50AttachedTest, getHeading_WhenTooLowAngularVelocityRead_WillNotUpdateH
 {
     const int gyroThreshold            = 12;
     const unsigned int expectedHeading = 1;
-    const int step                     = kInterval + 1;
-    int currentIteration               = 0;
+    const auto step                    = kInterval + 1;
+    unsigned long currentIteration     = 0;
     auto timer = [&step, &currentIteration]() { return ++currentIteration * step; };
     ON_CALL(mRuntime, currentTimeMillis()).WillByDefault(InvokeWithoutArgs(timer));
     ON_CALL(mRuntime, i2cAvailable()).WillByDefault(Return(1));

--- a/test/ut/GY50_test.cpp
+++ b/test/ut/GY50_test.cpp
@@ -207,14 +207,14 @@ TEST_F(GY50BasicTest, getOffset_WhenCalled_WillSetupSensorViaI2COnce)
 
 TEST_F(GY50BasicTest, getOffset_WhenCalled_WillReturnCorrectAverageOfMeasurements)
 {
-    unsigned int measurements = 100;
-    int msb                   = 0;
-    int highMeasurement       = 560;
-    int lowMeasurement        = -120;
-    int expectedOffset        = (lowMeasurement + highMeasurement) / 2;
-    int step                  = 0;
-    int token                 = 0;
-    auto mockReader           = [&step, &token, highMeasurement, lowMeasurement, msb]() {
+    int measurements    = 100;
+    int msb             = 0;
+    int highMeasurement = 560;
+    int lowMeasurement  = -120;
+    int expectedOffset  = (lowMeasurement + highMeasurement) / 2;
+    int step            = 0;
+    int token           = 0;
+    auto mockReader     = [&step, &token, highMeasurement, lowMeasurement, msb]() {
         auto measurement
             = step++ % 2 == 0 ? msb : (token++ % 2 == 0 ? highMeasurement : lowMeasurement);
         return measurement;

--- a/test/ut/InfraredAnalogSensor_test.cpp
+++ b/test/ut/InfraredAnalogSensor_test.cpp
@@ -6,10 +6,11 @@
 #include "MockRuntime.hpp"
 
 using namespace ::testing;
+using namespace smartcarlib::constants::distanceSensor;
 
 namespace
 {
-const auto kErrorReading                    = static_cast<unsigned int>(-1);
+const auto kErrorReading = static_cast<unsigned int>(-1);
 } // namespace
 
 class InfraredAnalogSensorTest : public Test
@@ -28,6 +29,14 @@ TEST_F(InfraredAnalogSensorTest, getMedianDistance_WhenNoIterations_WillReturnEr
 {
     uint8_t expectedMeasurements = 0;
     EXPECT_CALL(mInfraredAnalogSensor, getDistance()).Times(expectedMeasurements);
+
+    EXPECT_EQ(mInfraredAnalogSensor.getMedianDistance(expectedMeasurements), kErrorReading);
+}
+
+TEST_F(InfraredAnalogSensorTest, getMedianDistance_WhenTooManyIterations_WillReturnError)
+{
+    uint8_t expectedMeasurements = kMaxMedianMeasurements + 1;
+    EXPECT_CALL(mInfraredAnalogSensor, getDistance()).Times(0);
 
     EXPECT_EQ(mInfraredAnalogSensor.getMedianDistance(expectedMeasurements), kErrorReading);
 }

--- a/test/ut/SR04_test.cpp
+++ b/test/ut/SR04_test.cpp
@@ -80,7 +80,7 @@ TEST_F(SR04Test, getDistance_WhenCalled_WillMeasureCorrectly)
 
 TEST_F(SR04Test, getDistance_WhenCalculatedDistanceEqualToMaxDistance_WillReturnMaxDistance)
 {
-    unsigned long pulseLength     = kMaxDistance * kTimeToTravelOneCmAndBack;
+    const auto pulseLength        = static_cast<float>(kMaxDistance) * kTimeToTravelOneCmAndBack;
     unsigned int expectedDistance = kMaxDistance;
     unsigned long expectedTimeout = kMaxDistance * kTimeToMeasureOneCm;
 
@@ -92,7 +92,7 @@ TEST_F(SR04Test, getDistance_WhenCalculatedDistanceEqualToMaxDistance_WillReturn
         EXPECT_CALL(mRuntime, delayMicros(10));
         EXPECT_CALL(mRuntime, setPinState(kTriggerPin, kLow));
         EXPECT_CALL(mRuntime, getPulseDuration(kEchoPin, kHigh, expectedTimeout))
-            .WillOnce(Return(pulseLength));
+            .WillOnce(Return(static_cast<unsigned long>(pulseLength)));
     }
 
     EXPECT_EQ(mSR04->getDistance(), expectedDistance);

--- a/test/ut/SR04_test.cpp
+++ b/test/ut/SR04_test.cpp
@@ -16,7 +16,7 @@ const uint8_t kOutput                       = 1;
 const uint8_t kLow                          = 0;
 const uint8_t kHigh                         = 1;
 const unsigned int kMaxDistance             = 100;
-const auto kTimeToTravelOneCmAndBack        = 29.15 * 2;
+const auto kTimeToTravelOneCmAndBack        = 29.15f * 2.0f;
 const unsigned long kTimeToMeasureOneCm     = 120;
 const unsigned long kMedianMeasurementDelay = 15;
 const uint8_t kTriggerPin                   = 5;
@@ -61,7 +61,7 @@ TEST_F(SR04Test, getDistance_WhenSensorNotAttached_WillSetPinDirectionsOnce)
 TEST_F(SR04Test, getDistance_WhenCalled_WillMeasureCorrectly)
 {
     unsigned long pulseLength     = 200;
-    unsigned int expectedDistance = pulseLength / kTimeToTravelOneCmAndBack;
+    const auto expectedDistance   = static_cast<float>(pulseLength) / kTimeToTravelOneCmAndBack;
     unsigned long expectedTimeout = kMaxDistance * kTimeToMeasureOneCm;
 
     {
@@ -75,7 +75,7 @@ TEST_F(SR04Test, getDistance_WhenCalled_WillMeasureCorrectly)
             .WillOnce(Return(pulseLength));
     }
 
-    EXPECT_EQ(mSR04->getDistance(), expectedDistance);
+    EXPECT_EQ(mSR04->getDistance(), static_cast<unsigned int>(expectedDistance));
 }
 
 TEST_F(SR04Test, getDistance_WhenCalculatedDistanceEqualToMaxDistance_WillReturnMaxDistance)
@@ -101,7 +101,7 @@ TEST_F(SR04Test, getDistance_WhenCalculatedDistanceEqualToMaxDistance_WillReturn
 TEST_F(SR04Test, getDistance_WhenCalculatedDistanceMoreThanMaxDistance_WillReturnError)
 {
     // kMaxDistance + 1 not enough due to rounding down
-    unsigned long pulseLength     = (kMaxDistance + 2) * kTimeToTravelOneCmAndBack;
+    const auto pulseLength        = (kMaxDistance + 2) * kTimeToTravelOneCmAndBack;
     unsigned int expectedDistance = kError;
     unsigned long expectedTimeout = kMaxDistance * kTimeToMeasureOneCm;
 
@@ -113,7 +113,7 @@ TEST_F(SR04Test, getDistance_WhenCalculatedDistanceMoreThanMaxDistance_WillRetur
         EXPECT_CALL(mRuntime, delayMicros(10));
         EXPECT_CALL(mRuntime, setPinState(kTriggerPin, kLow));
         EXPECT_CALL(mRuntime, getPulseDuration(kEchoPin, kHigh, expectedTimeout))
-            .WillOnce(Return(pulseLength));
+            .WillOnce(Return(static_cast<unsigned long>(pulseLength)));
     }
 
     EXPECT_EQ(mSR04->getDistance(), expectedDistance);
@@ -121,14 +121,14 @@ TEST_F(SR04Test, getDistance_WhenCalculatedDistanceMoreThanMaxDistance_WillRetur
 
 TEST_F(SR04BadMaxDistanceTest, getDistance_WhenBadMaxDistanceSupplied_WillUseDefaultMaxDistance)
 {
-    unsigned long pulseLength     = 200;
-    unsigned int expectedDistance = pulseLength / kTimeToTravelOneCmAndBack;
+    const auto pulseLength        = 200.0f;
+    const auto expectedDistance   = pulseLength / kTimeToTravelOneCmAndBack;
     unsigned long expectedTimeout = kDefaultMaxDistance * kTimeToMeasureOneCm;
 
     EXPECT_CALL(mRuntime, getPulseDuration(kEchoPin, kHigh, expectedTimeout))
         .WillOnce(Return(pulseLength));
 
-    EXPECT_EQ(mSR04->getDistance(), expectedDistance);
+    EXPECT_EQ(mSR04->getDistance(), static_cast<unsigned int>(expectedDistance));
 }
 
 TEST_F(SR04Test, getMedianDistance_WhenNoIterations_WillReturnError)

--- a/test/ut/SR04_test.cpp
+++ b/test/ut/SR04_test.cpp
@@ -7,6 +7,7 @@
 
 using namespace ::testing;
 using namespace smartcarlib::constants::sr04;
+using namespace smartcarlib::constants::distanceSensor;
 
 namespace
 {
@@ -135,6 +136,15 @@ TEST_F(SR04Test, getMedianDistance_WhenNoIterations_WillReturnError)
     uint8_t expectedMeasurements = 0;
 
     EXPECT_CALL(mRuntime, getPulseDuration(_, _, _)).Times(expectedMeasurements);
+
+    EXPECT_EQ(mSR04->getMedianDistance(expectedMeasurements), kError);
+}
+
+TEST_F(SR04Test, getMedianDistance_WhenTooManyIterations_WillReturnError)
+{
+    uint8_t expectedMeasurements = kMaxMedianMeasurements + 1;
+
+    EXPECT_CALL(mRuntime, getPulseDuration(_, _, _)).Times(0);
 
     EXPECT_EQ(mSR04->getMedianDistance(expectedMeasurements), kError);
 }

--- a/test/ut/SRF08_test.cpp
+++ b/test/ut/SRF08_test.cpp
@@ -222,7 +222,7 @@ TEST_F(SRF08Test, changeAddress_WhenCalled_WillChangeAddress)
         EXPECT_CALL(mRuntime, i2cWrite(thirdInChangeAddressSequence));
 
         EXPECT_CALL(mRuntime, i2cWrite(kRangingCommandRegister));
-        EXPECT_CALL(mRuntime, i2cWrite(newAddress << 1));
+        EXPECT_CALL(mRuntime, i2cWrite(static_cast<uint8_t>(newAddress << 0x01)));
     }
 
     EXPECT_EQ(mSRF08.changeAddress(newAddress), newAddress);

--- a/test/ut/SRF08_test.cpp
+++ b/test/ut/SRF08_test.cpp
@@ -59,8 +59,8 @@ TEST_F(SRF08Test, getDistance_WhenI2cNotInitialized_WillInitializeBusOnce)
 
 TEST_F(SRF08Test, getDistance_WhenBusAvailable_WillReturnCorrectDistance)
 {
-    auto expectedReading = 267;
-    auto expectedBytes   = readingToBytes(expectedReading);
+    unsigned int expectedReading = 267;
+    auto expectedBytes           = readingToBytes(expectedReading);
     Sequence rangingSequence, readingSequence;
 
     EXPECT_CALL(mRuntime, i2cAvailable()).WillOnce(Return(1));

--- a/test/ut/SRF08_test.cpp
+++ b/test/ut/SRF08_test.cpp
@@ -9,6 +9,7 @@
 #include "SRF08.hpp"
 
 using namespace ::testing;
+using namespace smartcarlib::constants::distanceSensor;
 
 namespace
 {
@@ -82,6 +83,14 @@ TEST_F(SRF08Test, getMedianDistance_WhenNoIterations_WillReturnError)
 {
     uint8_t expectedMeasurements = 0;
     EXPECT_CALL(mRuntime, i2cRead()).Times(expectedMeasurements);
+
+    EXPECT_EQ(mSRF08.getMedianDistance(expectedMeasurements), kErrorReading);
+}
+
+TEST_F(SRF08Test, getMedianDistance_WhenTooManyIterations_WillReturnError)
+{
+    uint8_t expectedMeasurements = kMaxMedianMeasurements + 1;
+    EXPECT_CALL(mRuntime, i2cRead()).Times(0);
 
     EXPECT_EQ(mSRF08.getMedianDistance(expectedMeasurements), kErrorReading);
 }

--- a/test/ut/SharpSensors_test.cpp
+++ b/test/ut/SharpSensors_test.cpp
@@ -10,8 +10,7 @@ using namespace ::testing;
 
 namespace
 {
-const uint8_t kPin       = 5;
-const auto kErrorReading = static_cast<unsigned int>(-1);
+const uint8_t kPin = 5;
 } // namespace
 
 class GP2D120Test : public Test

--- a/test/ut/SimpleCar_test.cpp
+++ b/test/ut/SimpleCar_test.cpp
@@ -39,7 +39,7 @@ TEST_F(SimpleCarTest, setSpeed_WhenTooLowSpeed_WillSetMinSpeed)
 
 TEST_F(SimpleCarTest, setSpeed_WhenValidSpeed_WillSetCorrectSpeed)
 {
-    float speed       = 45.2;
+    float speed       = 45.2f;
     int expectedSpeed = static_cast<int>(speed);
     EXPECT_CALL(mControl, setSpeed(expectedSpeed));
 

--- a/test/ut/Utilities_test.cpp
+++ b/test/ut/Utilities_test.cpp
@@ -11,47 +11,48 @@ using namespace smartcarlib::utils;
 
 namespace
 {
-unsigned int expectedMedian = 25;
+const unsigned int expectedMedian = 25;
 std::vector<unsigned int> readings{ 12, expectedMedian, 0, 55, 300 };
+const auto kReadingsSize = static_cast<unsigned int>(readings.size());
 } // namespace
 
 TEST(MedianTest, getMedian_WhenCalledWithUnsortedArray_WillReturnMedian)
 {
-    EXPECT_EQ(getMedian(&readings[0], readings.size()), expectedMedian);
+    EXPECT_EQ(getMedian(&readings[0], kReadingsSize), expectedMedian);
 }
 
 TEST(MedianTest, getMedian_WhenCalledWithAscendingArray_WillReturnMedian)
 {
     std::sort(readings.begin(), readings.end());
-    EXPECT_EQ(getMedian(&readings[0], readings.size()), expectedMedian);
+    EXPECT_EQ(getMedian(&readings[0], kReadingsSize), expectedMedian);
 }
 
 TEST(MedianTest, getMedian_WhenCalledWithDescendingArray_WillReturnMedian)
 {
     std::reverse(readings.begin(), readings.end());
-    EXPECT_EQ(getMedian(&readings[0], readings.size()), expectedMedian);
+    EXPECT_EQ(getMedian(&readings[0], kReadingsSize), expectedMedian);
 }
 
 TEST(ConstrainTest, getConstrain_WhenSmallerThanMinimum_WillReturnMinimum)
 {
-    auto min = 40;
-    auto max = 120;
+    auto min              = 40;
+    auto max              = 120;
     auto valueToConstrain = -2;
     EXPECT_EQ(getConstrain(valueToConstrain, min, max), min);
 }
 
 TEST(ConstrainTest, getConstrain_WhenLargerThanMaximum_WillReturnMaximum)
 {
-    auto min = -300;
-    auto max = -50;
+    auto min              = -300;
+    auto max              = -50;
     auto valueToConstrain = 0;
     EXPECT_EQ(getConstrain(valueToConstrain, min, max), max);
 }
 
 TEST(ConstrainTest, getConstrain_WhenWithinRange_WillReturnNumber)
 {
-    auto min = -4;
-    auto max = 24;
+    auto min              = -4;
+    auto max              = 24;
     auto valueToConstrain = 1;
     EXPECT_EQ(getConstrain(valueToConstrain, min, max), valueToConstrain);
 }
@@ -70,11 +71,11 @@ TEST(AbsoluteTest, getAbsolute_WhenNonNegativeNumber_WillReturnNumber)
 
 TEST(MapTest, getMap_WhenInvalidRange_WillReturnLowerTargetRangeLimit)
 {
-    int valueToMap = 5;
-    int fromLow = 100;
-    int fromHigh = 100;
-    int toLow = 0;
-    int toHigh = 1000;
+    int valueToMap    = 5;
+    int fromLow       = 100;
+    int fromHigh      = 100;
+    int toLow         = 0;
+    int toHigh        = 1000;
     int expectedValue = toLow;
 
     EXPECT_EQ(getMap(valueToMap, fromLow, fromHigh, toLow, toHigh), expectedValue);
@@ -82,11 +83,11 @@ TEST(MapTest, getMap_WhenInvalidRange_WillReturnLowerTargetRangeLimit)
 
 TEST(MapTest, getMap_WhenValidArguments_WillReturnValidMappedValue)
 {
-    int fromLow = 0;
-    int fromHigh = 100;
-    int valueToMap = fromHigh / 4;
-    int toLow = 0;
-    int toHigh = 1000;
+    int fromLow       = 0;
+    int fromHigh      = 100;
+    int valueToMap    = fromHigh / 4;
+    int toLow         = 0;
+    int toHigh        = 1000;
     int expectedValue = toHigh / 4;
 
     EXPECT_EQ(getMap(valueToMap, fromLow, fromHigh, toLow, toHigh), expectedValue);
@@ -94,12 +95,12 @@ TEST(MapTest, getMap_WhenValidArguments_WillReturnValidMappedValue)
 
 TEST(MapTest, getMap_WhenFloatArguments_WillReturnValidFloatValue)
 {
-    float fromLow = 0;
-    float fromHigh = 100;
-    float valueToMap = fromHigh / 3.5;
-    float toLow = 0;
-    float toHigh = 1000;
-    float expectedValue = toHigh / 3.5;
+    float fromLow       = 0;
+    float fromHigh      = 100.0f;
+    float valueToMap    = fromHigh / 3.5f;
+    float toLow         = 0;
+    float toHigh        = 1000.0f;
+    float expectedValue = toHigh / 3.5f;
 
     EXPECT_FLOAT_EQ(getMap(valueToMap, fromLow, fromHigh, toLow, toHigh), expectedValue);
 }


### PR DESCRIPTION
## Description
Getting inspired from #22 I noticed that we were not using many flags in our unit test compilation.
After adding a bunch of them, many errors surfaced and they were fixed. The compilers that were used were `gcc` version `9.3.0` and `clang` version `9.0.0` (which we should consider adding to the CI).

There is a slight API change (backwards compatible for the most part) where the maximum allowed number of median iterations is `100`.

## Solved issue(s)
Fixes #22 