### PR TITLE
Remove hardcoded arduino runtime injection

### DIFF
--- a/examples/Car/DistanceCar/DistanceCar.ino
+++ b/examples/Car/DistanceCar/DistanceCar.ino
@@ -1,17 +1,24 @@
 #include <Smartcar.h>
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::leftOdometerPin,
+    []() { leftOdometer.update(); },
+    pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::rightOdometerPin,
+    []() { rightOdometer.update(); },
+    pulsesPerMeter);
 
-DistanceCar car(control, leftOdometer, rightOdometer);
+DistanceCar car(arduino, control, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/DistanceCar/DistanceCar.ino
+++ b/examples/Car/DistanceCar/DistanceCar.ino
@@ -1,24 +1,24 @@
 #include <Smartcar.h>
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::leftOdometerPin,
     []() { leftOdometer.update(); },
     pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::rightOdometerPin,
     []() { rightOdometer.update(); },
     pulsesPerMeter);
 
-DistanceCar car(arduino, control, leftOdometer, rightOdometer);
+DistanceCar car(arduinoRuntime, control, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/FullSerialControl/FullSerialControl.ino
+++ b/examples/Car/FullSerialControl/FullSerialControl.ino
@@ -1,7 +1,8 @@
 #include <Smartcar.h>
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);

--- a/examples/Car/FullSerialControl/FullSerialControl.ino
+++ b/examples/Car/FullSerialControl/FullSerialControl.ino
@@ -1,8 +1,8 @@
 #include <Smartcar.h>
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);

--- a/examples/Car/HeadingCar/HeadingCar.ino
+++ b/examples/Car/HeadingCar/HeadingCar.ino
@@ -4,11 +4,12 @@ const int GYROSCOPE_OFFSET         = 37;
 const unsigned long PRINT_INTERVAL = 100;
 unsigned long previousPrintout     = 0;
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
-GY50 gyroscope(GYROSCOPE_OFFSET);
+GY50 gyroscope(arduino, GYROSCOPE_OFFSET);
 
 HeadingCar car(control, gyroscope);
 

--- a/examples/Car/HeadingCar/HeadingCar.ino
+++ b/examples/Car/HeadingCar/HeadingCar.ino
@@ -4,12 +4,12 @@ const int GYROSCOPE_OFFSET         = 37;
 const unsigned long PRINT_INTERVAL = 100;
 unsigned long previousPrintout     = 0;
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
-GY50 gyroscope(arduino, GYROSCOPE_OFFSET);
+GY50 gyroscope(arduinoRuntime, GYROSCOPE_OFFSET);
 
 HeadingCar car(control, gyroscope);
 

--- a/examples/Car/PidControllerMonitor/PidControllerMonitor.ino
+++ b/examples/Car/PidControllerMonitor/PidControllerMonitor.ino
@@ -9,25 +9,25 @@ const unsigned long PRINTOUT_INTERVAL = 100;
 unsigned long previousPrintOut        = 0;
 float carSpeed                        = 0.5;
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::leftOdometerPin,
     []() { leftOdometer.update(); },
     pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::rightOdometerPin,
     []() { rightOdometer.update(); },
     pulsesPerMeter);
 
-DistanceCar car(arduino, control, leftOdometer, rightOdometer);
+DistanceCar car(arduinoRuntime, control, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/PidControllerMonitor/PidControllerMonitor.ino
+++ b/examples/Car/PidControllerMonitor/PidControllerMonitor.ino
@@ -9,18 +9,25 @@ const unsigned long PRINTOUT_INTERVAL = 100;
 unsigned long previousPrintOut        = 0;
 float carSpeed                        = 0.5;
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::leftOdometerPin,
+    []() { leftOdometer.update(); },
+    pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::rightOdometerPin,
+    []() { rightOdometer.update(); },
+    pulsesPerMeter);
 
-DistanceCar car(control, leftOdometer, rightOdometer);
+DistanceCar car(arduino, control, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/SimpleCar/SimpleCar.ino
+++ b/examples/Car/SimpleCar/SimpleCar.ino
@@ -1,7 +1,8 @@
 #include <Smartcar.h>
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);

--- a/examples/Car/SimpleCar/SimpleCar.ino
+++ b/examples/Car/SimpleCar/SimpleCar.ino
@@ -1,8 +1,8 @@
 #include <Smartcar.h>
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);

--- a/examples/Car/SmartCar/SmartCar.ino
+++ b/examples/Car/SmartCar/SmartCar.ino
@@ -3,20 +3,27 @@
 const unsigned long PRINT_INTERVAL = 100;
 unsigned long previousPrintout     = 0;
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
-GY50 gyroscope(37);
+GY50 gyroscope(arduino, 37);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::leftOdometerPin,
+    []() { leftOdometer.update(); },
+    pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::rightOdometerPin,
+    []() { rightOdometer.update(); },
+    pulsesPerMeter);
 
-SmartCar car(control, gyroscope, leftOdometer, rightOdometer);
+SmartCar car(arduino, control, gyroscope, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/SmartCar/SmartCar.ino
+++ b/examples/Car/SmartCar/SmartCar.ino
@@ -3,27 +3,27 @@
 const unsigned long PRINT_INTERVAL = 100;
 unsigned long previousPrintout     = 0;
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
-GY50 gyroscope(arduino, 37);
+GY50 gyroscope(arduinoRuntime, 37);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::leftOdometerPin,
     []() { leftOdometer.update(); },
     pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::rightOdometerPin,
     []() { rightOdometer.update(); },
     pulsesPerMeter);
 
-SmartCar car(arduino, control, gyroscope, leftOdometer, rightOdometer);
+SmartCar car(arduinoRuntime, control, gyroscope, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/automatedMovements/automatedMovements.ino
+++ b/examples/Car/automatedMovements/automatedMovements.ino
@@ -4,27 +4,27 @@ const float carSpeed        = 1.0;
 const long distanceToTravel = 40;
 const int degreesToTurn     = 90;
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
-GY50 gyroscope(arduino, 37);
+GY50 gyroscope(arduinoRuntime, 37);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::leftOdometerPin,
     []() { leftOdometer.update(); },
     pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::rightOdometerPin,
     []() { rightOdometer.update(); },
     pulsesPerMeter);
 
-SmartCar car(arduino, control, gyroscope, leftOdometer, rightOdometer);
+SmartCar car(arduinoRuntime, control, gyroscope, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/automatedMovements/automatedMovements.ino
+++ b/examples/Car/automatedMovements/automatedMovements.ino
@@ -4,20 +4,27 @@ const float carSpeed        = 1.0;
 const long distanceToTravel = 40;
 const int degreesToTurn     = 90;
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
-GY50 gyroscope(37);
+GY50 gyroscope(arduino, 37);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::leftOdometerPin,
+    []() { leftOdometer.update(); },
+    pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::rightOdometerPin,
+    []() { rightOdometer.update(); },
+    pulsesPerMeter);
 
-SmartCar car(control, gyroscope, leftOdometer, rightOdometer);
+SmartCar car(arduino, control, gyroscope, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/manualControl/manualControl.ino
+++ b/examples/Car/manualControl/manualControl.ino
@@ -5,8 +5,9 @@ const int bSpeed   = -70; // 70% of the full speed backward
 const int lDegrees = -75; // degrees to turn left
 const int rDegrees = 75;  // degrees to turn right
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);

--- a/examples/Car/manualControl/manualControl.ino
+++ b/examples/Car/manualControl/manualControl.ino
@@ -5,9 +5,9 @@ const int bSpeed   = -70; // 70% of the full speed backward
 const int lDegrees = -75; // degrees to turn left
 const int rDegrees = 75;  // degrees to turn right
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);

--- a/examples/Car/manualWithCruiseControl/manualWithCruiseControl.ino
+++ b/examples/Car/manualWithCruiseControl/manualWithCruiseControl.ino
@@ -5,25 +5,25 @@ const float bSpeed = -0.5; // a ground speed (m/sec)y for going backward
 const int lDegrees = -75;  // degrees to turn left
 const int rDegrees = 75;   // degrees to turn right
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::leftOdometerPin,
     []() { leftOdometer.update(); },
     pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::rightOdometerPin,
     []() { rightOdometer.update(); },
     pulsesPerMeter);
 
-DistanceCar car(arduino, control, leftOdometer, rightOdometer);
+DistanceCar car(arduinoRuntime, control, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/manualWithCruiseControl/manualWithCruiseControl.ino
+++ b/examples/Car/manualWithCruiseControl/manualWithCruiseControl.ino
@@ -5,18 +5,25 @@ const float bSpeed = -0.5; // a ground speed (m/sec)y for going backward
 const int lDegrees = -75;  // degrees to turn left
 const int rDegrees = 75;   // degrees to turn right
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
 DirectionlessOdometer leftOdometer(
-    smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::leftOdometerPin,
+    []() { leftOdometer.update(); },
+    pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::rightOdometerPin,
+    []() { rightOdometer.update(); },
+    pulsesPerMeter);
 
-DistanceCar car(control, leftOdometer, rightOdometer);
+DistanceCar car(arduino, control, leftOdometer, rightOdometer);
 
 void setup()
 {

--- a/examples/Car/rotateOnSpot/rotateOnSpot.ino
+++ b/examples/Car/rotateOnSpot/rotateOnSpot.ino
@@ -3,11 +3,12 @@
 const int carSpeed         = 80; // 80% of the max speed
 const int GYROSCOPE_OFFSET = 37;
 
-BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
-GY50 gyroscope(GYROSCOPE_OFFSET);
+GY50 gyroscope(arduino, GYROSCOPE_OFFSET);
 
 HeadingCar car(control, gyroscope);
 

--- a/examples/Car/rotateOnSpot/rotateOnSpot.ino
+++ b/examples/Car/rotateOnSpot/rotateOnSpot.ino
@@ -3,12 +3,12 @@
 const int carSpeed         = 80; // 80% of the max speed
 const int GYROSCOPE_OFFSET = 37;
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
-GY50 gyroscope(arduino, GYROSCOPE_OFFSET);
+GY50 gyroscope(arduinoRuntime, GYROSCOPE_OFFSET);
 
 HeadingCar car(control, gyroscope);
 

--- a/examples/Car/shieldMotorsTest/shieldMotorsTest.ino
+++ b/examples/Car/shieldMotorsTest/shieldMotorsTest.ino
@@ -11,8 +11,9 @@
 
 #include <Smartcar.h>
 
-BrushedMotor leftMotor(smartcarlib::pins::v1::leftMotorPins);
-BrushedMotor rightMotor(smartcarlib::pins::v1::rightMotorPins);
+ArduinoRuntime arduino;
+BrushedMotor leftMotor(arduino, smartcarlib::pins::v1::leftMotorPins);
+BrushedMotor rightMotor(arduino, smartcarlib::pins::v1::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);

--- a/examples/Car/shieldMotorsTest/shieldMotorsTest.ino
+++ b/examples/Car/shieldMotorsTest/shieldMotorsTest.ino
@@ -11,9 +11,9 @@
 
 #include <Smartcar.h>
 
-ArduinoRuntime arduino;
-BrushedMotor leftMotor(arduino, smartcarlib::pins::v1::leftMotorPins);
-BrushedMotor rightMotor(arduino, smartcarlib::pins::v1::rightMotorPins);
+ArduinoRuntime arduinoRuntime;
+BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v1::leftMotorPins);
+BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v1::rightMotorPins);
 DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);

--- a/examples/sensors/gyroscope/gyroscopeCalibration/gyroscopeCalibration.ino
+++ b/examples/sensors/gyroscope/gyroscopeCalibration/gyroscopeCalibration.ino
@@ -1,17 +1,19 @@
 #include <Smartcar.h>
 
-GY50 gyro(0); // Provide the gyroscope with a random offset
+ArduinoRuntime arduino;
+GY50 gyro(arduino, 0); // Provide the gyroscope with a random offset
 
-void setup() {
-  Serial.begin(9600);
-  Serial.println("Calibrating gyroscope, this might take some seconds");
-  int offset = gyro.getOffset();
-  Serial.print("This gyro's offset value is: ");
-  Serial.println(offset);
-  Serial.print("Please initialize Gyroscope with the above value as: GY50 gyro(");
-  Serial.print(offset);
-  Serial.println("); or another similar value that works better according to your experimentation.");
+void setup()
+{
+    Serial.begin(9600);
+    Serial.println("Calibrating gyroscope, this might take some seconds");
+    int offset = gyro.getOffset();
+    Serial.print("This gyro's offset value is: ");
+    Serial.println(offset);
+    Serial.print("Please initialize Gyroscope with the above value as: GY50 gyro(");
+    Serial.print(offset);
+    Serial.println(
+        "); or another similar value that works better according to your experimentation.");
 }
 
-void loop() {
-}
+void loop() {}

--- a/examples/sensors/gyroscope/gyroscopeCalibration/gyroscopeCalibration.ino
+++ b/examples/sensors/gyroscope/gyroscopeCalibration/gyroscopeCalibration.ino
@@ -1,7 +1,7 @@
 #include <Smartcar.h>
 
-ArduinoRuntime arduino;
-GY50 gyro(arduino, 0); // Provide the gyroscope with a random offset
+ArduinoRuntime arduinoRuntime;
+GY50 gyro(arduinoRuntime, 0); // Provide the gyroscope with a random offset
 
 void setup()
 {

--- a/examples/sensors/gyroscope/gyroscopeHeading/gyroscopeHeading.ino
+++ b/examples/sensors/gyroscope/gyroscopeHeading/gyroscopeHeading.ino
@@ -1,9 +1,9 @@
 #include <Smartcar.h>
 
-ArduinoRuntime arduino;
+ArduinoRuntime arduinoRuntime;
 // Determine the offset for your gyroscope using the `getOffset` method
 const int GYROSCOPE_OFFSET = 37;
-GY50 gyro(arduino, GYROSCOPE_OFFSET);
+GY50 gyro(arduinoRuntime, GYROSCOPE_OFFSET);
 
 void setup()
 {

--- a/examples/sensors/gyroscope/gyroscopeHeading/gyroscopeHeading.ino
+++ b/examples/sensors/gyroscope/gyroscopeHeading/gyroscopeHeading.ino
@@ -1,17 +1,20 @@
 #include <Smartcar.h>
 
+ArduinoRuntime arduino;
 // Determine the offset for your gyroscope using the `getOffset` method
 const int GYROSCOPE_OFFSET = 37;
-GY50 gyro(GYROSCOPE_OFFSET);
+GY50 gyro(arduino, GYROSCOPE_OFFSET);
 
-void setup() {
-  Serial.begin(9600);
-  delay(1500);
+void setup()
+{
+    Serial.begin(9600);
+    delay(1500);
 }
 
-void loop() {
-  // Update the readings of the gyroscope
-  // You should have this method being freely executed within your main loop
-  gyro.update();
-  Serial.println(gyro.getHeading());
+void loop()
+{
+    // Update the readings of the gyroscope
+    // You should have this method being freely executed within your main loop
+    gyro.update();
+    Serial.println(gyro.getHeading());
 }

--- a/examples/sensors/infrareds/GP2D120/GP2D120.ino
+++ b/examples/sensors/infrareds/GP2D120/GP2D120.ino
@@ -1,13 +1,17 @@
 #include <Smartcar.h>
 
-const int SIDE_FRONT_PIN = A0; //you can use only analog enabled pins
-GP2D120 sideFrontIR(SIDE_FRONT_PIN); //measure distances between 5 and 25 centimeters
+const int SIDE_FRONT_PIN = A0; // you can use only analog enabled pins
 
-void setup() {
-  Serial.begin(9600); //start the serial
+ArduinoRuntime arduino;
+GP2D120 sideFrontIR(arduino, SIDE_FRONT_PIN); // measure distances between 5 and 25 centimeters
+
+void setup()
+{
+    Serial.begin(9600); // start the serial
 }
 
-void loop() {
-  Serial.println(sideFrontIR.getDistance());
-  delay(100);
+void loop()
+{
+    Serial.println(sideFrontIR.getDistance());
+    delay(100);
 }

--- a/examples/sensors/infrareds/GP2D120/GP2D120.ino
+++ b/examples/sensors/infrareds/GP2D120/GP2D120.ino
@@ -2,8 +2,9 @@
 
 const int SIDE_FRONT_PIN = A0; // you can use only analog enabled pins
 
-ArduinoRuntime arduino;
-GP2D120 sideFrontIR(arduino, SIDE_FRONT_PIN); // measure distances between 5 and 25 centimeters
+ArduinoRuntime arduinoRuntime;
+GP2D120 sideFrontIR(arduinoRuntime,
+                    SIDE_FRONT_PIN); // measure distances between 5 and 25 centimeters
 
 void setup()
 {

--- a/examples/sensors/infrareds/GP2Y0A02/GP2Y0A02.ino
+++ b/examples/sensors/infrareds/GP2Y0A02/GP2Y0A02.ino
@@ -1,13 +1,17 @@
 #include <Smartcar.h>
 
 const int SIDE_FRONT_PIN = A0;
-GP2Y0A02 sideFrontIR(SIDE_FRONT_PIN); //measure distances between 25 and 120 centimeters
 
-void setup() {
-  Serial.begin(9600); //start the serial
+ArduinoRuntime arduino;
+GP2Y0A02 sideFrontIR(arduino, SIDE_FRONT_PIN); // measure distances between 25 and 120 centimeters
+
+void setup()
+{
+    Serial.begin(9600); // start the serial
 }
 
-void loop() {
-  Serial.println(sideFrontIR.getDistance());
-  delay(100);
+void loop()
+{
+    Serial.println(sideFrontIR.getDistance());
+    delay(100);
 }

--- a/examples/sensors/infrareds/GP2Y0A02/GP2Y0A02.ino
+++ b/examples/sensors/infrareds/GP2Y0A02/GP2Y0A02.ino
@@ -2,8 +2,9 @@
 
 const int SIDE_FRONT_PIN = A0;
 
-ArduinoRuntime arduino;
-GP2Y0A02 sideFrontIR(arduino, SIDE_FRONT_PIN); // measure distances between 25 and 120 centimeters
+ArduinoRuntime arduinoRuntime;
+GP2Y0A02 sideFrontIR(arduinoRuntime,
+                     SIDE_FRONT_PIN); // measure distances between 25 and 120 centimeters
 
 void setup()
 {

--- a/examples/sensors/infrareds/GP2Y0A21/GP2Y0A21.ino
+++ b/examples/sensors/infrareds/GP2Y0A21/GP2Y0A21.ino
@@ -2,8 +2,9 @@
 
 const int SIDE_FRONT_PIN = A0;
 
-ArduinoRuntime arduino;
-GP2Y0A21 sideFrontIR(arduino, SIDE_FRONT_PIN); // measure distances between 12 and 78 centimeters
+ArduinoRuntime arduinoRuntime;
+GP2Y0A21 sideFrontIR(arduinoRuntime,
+                     SIDE_FRONT_PIN); // measure distances between 12 and 78 centimeters
 
 void setup()
 {

--- a/examples/sensors/infrareds/GP2Y0A21/GP2Y0A21.ino
+++ b/examples/sensors/infrareds/GP2Y0A21/GP2Y0A21.ino
@@ -1,13 +1,17 @@
 #include <Smartcar.h>
 
 const int SIDE_FRONT_PIN = A0;
-GP2Y0A21 sideFrontIR(SIDE_FRONT_PIN); //measure distances between 12 and 78 centimeters
 
-void setup() {
-  Serial.begin(9600); //start the serial
+ArduinoRuntime arduino;
+GP2Y0A21 sideFrontIR(arduino, SIDE_FRONT_PIN); // measure distances between 12 and 78 centimeters
+
+void setup()
+{
+    Serial.begin(9600); // start the serial
 }
 
-void loop() {
-  Serial.println(sideFrontIR.getDistance());
-  delay(100);
+void loop()
+{
+    Serial.println(sideFrontIR.getDistance());
+    delay(100);
 }

--- a/examples/sensors/odometer/directionalOdometers/directionalOdometers.ino
+++ b/examples/sensors/odometer/directionalOdometers/directionalOdometers.ino
@@ -3,14 +3,14 @@
 const unsigned long LEFT_PULSES_PER_METER  = 600;
 const unsigned long RIGHT_PULSES_PER_METER = 740;
 
-ArduinoRuntime arduino;
+ArduinoRuntime arduinoRuntime;
 DirectionalOdometer leftOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::leftOdometerPins,
     []() { leftOdometer.update(); },
     LEFT_PULSES_PER_METER);
 DirectionalOdometer rightOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::rightOdometerPins,
     []() { rightOdometer.update(); },
     RIGHT_PULSES_PER_METER);

--- a/examples/sensors/odometer/directionalOdometers/directionalOdometers.ino
+++ b/examples/sensors/odometer/directionalOdometers/directionalOdometers.ino
@@ -3,11 +3,14 @@
 const unsigned long LEFT_PULSES_PER_METER  = 600;
 const unsigned long RIGHT_PULSES_PER_METER = 740;
 
+ArduinoRuntime arduino;
 DirectionalOdometer leftOdometer(
+    arduino,
     smartcarlib::pins::v2::leftOdometerPins,
     []() { leftOdometer.update(); },
     LEFT_PULSES_PER_METER);
 DirectionalOdometer rightOdometer(
+    arduino,
     smartcarlib::pins::v2::rightOdometerPins,
     []() { rightOdometer.update(); },
     RIGHT_PULSES_PER_METER);

--- a/examples/sensors/odometer/findPulsesPerMeter/findPulsesPerMeter.ino
+++ b/examples/sensors/odometer/findPulsesPerMeter/findPulsesPerMeter.ino
@@ -3,9 +3,9 @@
 const unsigned short odometerPin   = 2;
 const unsigned long pulsesPerMeter = 100;
 
-ArduinoRuntime arduino;
+ArduinoRuntime arduinoRuntime;
 DirectionlessOdometer odometer(
-    arduino, odometerPin, []() { odometer.update(); }, pulsesPerMeter);
+    arduinoRuntime, odometerPin, []() { odometer.update(); }, pulsesPerMeter);
 
 void setup()
 {

--- a/examples/sensors/odometer/findPulsesPerMeter/findPulsesPerMeter.ino
+++ b/examples/sensors/odometer/findPulsesPerMeter/findPulsesPerMeter.ino
@@ -3,8 +3,9 @@
 const unsigned short odometerPin   = 2;
 const unsigned long pulsesPerMeter = 100;
 
+ArduinoRuntime arduino;
 DirectionlessOdometer odometer(
-    odometerPin, []() { odometer.update(); }, pulsesPerMeter);
+    arduino, odometerPin, []() { odometer.update(); }, pulsesPerMeter);
 
 void setup()
 {

--- a/examples/sensors/odometer/singleOdometer/singleOdometer.ino
+++ b/examples/sensors/odometer/singleOdometer/singleOdometer.ino
@@ -3,9 +3,9 @@
 const unsigned short odometerPin   = 2;
 const unsigned long pulsesPerMeter = 400;
 
-ArduinoRuntime arduino;
+ArduinoRuntime arduinoRuntime;
 DirectionlessOdometer odometer(
-    arduino, odometerPin, []() { odometer.update(); }, pulsesPerMeter);
+    arduinoRuntime, odometerPin, []() { odometer.update(); }, pulsesPerMeter);
 
 void setup()
 {

--- a/examples/sensors/odometer/singleOdometer/singleOdometer.ino
+++ b/examples/sensors/odometer/singleOdometer/singleOdometer.ino
@@ -3,8 +3,9 @@
 const unsigned short odometerPin   = 2;
 const unsigned long pulsesPerMeter = 400;
 
+ArduinoRuntime arduino;
 DirectionlessOdometer odometer(
-    odometerPin, []() { odometer.update(); }, pulsesPerMeter);
+    arduino, odometerPin, []() { odometer.update(); }, pulsesPerMeter);
 
 void setup()
 {

--- a/examples/sensors/odometer/twoOdometers/twoOdometers.ino
+++ b/examples/sensors/odometer/twoOdometers/twoOdometers.ino
@@ -2,10 +2,17 @@
 
 const auto pulsesPerMeter = 600;
 
+ArduinoRuntime arduino;
 DirectionlessOdometer leftOdometer(
-    smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::leftOdometerPin,
+    []() { leftOdometer.update(); },
+    pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); }, pulsesPerMeter);
+    arduino,
+    smartcarlib::pins::v2::rightOdometerPin,
+    []() { rightOdometer.update(); },
+    pulsesPerMeter);
 
 void setup()
 {

--- a/examples/sensors/odometer/twoOdometers/twoOdometers.ino
+++ b/examples/sensors/odometer/twoOdometers/twoOdometers.ino
@@ -2,14 +2,14 @@
 
 const auto pulsesPerMeter = 600;
 
-ArduinoRuntime arduino;
+ArduinoRuntime arduinoRuntime;
 DirectionlessOdometer leftOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::leftOdometerPin,
     []() { leftOdometer.update(); },
     pulsesPerMeter);
 DirectionlessOdometer rightOdometer(
-    arduino,
+    arduinoRuntime,
     smartcarlib::pins::v2::rightOdometerPin,
     []() { rightOdometer.update(); },
     pulsesPerMeter);

--- a/examples/sensors/ultrasounds/SR04/SR04.ino
+++ b/examples/sensors/ultrasounds/SR04/SR04.ino
@@ -1,17 +1,19 @@
 #include <Smartcar.h>
 
-const int TRIGGER_PIN = 6; //D6
-const int ECHO_PIN = 7; //D7
+const int TRIGGER_PIN           = 6; // D6
+const int ECHO_PIN              = 7; // D7
 const unsigned int MAX_DISTANCE = 100;
-SR04 front(TRIGGER_PIN, ECHO_PIN, MAX_DISTANCE);
 
+ArduinoRuntime arduino;
+SR04 front(arduino, TRIGGER_PIN, ECHO_PIN, MAX_DISTANCE);
 
-void setup() {
-  Serial.begin(9600);
+void setup()
+{
+    Serial.begin(9600);
 }
 
-void loop() {
-  Serial.println(front.getDistance());
-  delay(100);
+void loop()
+{
+    Serial.println(front.getDistance());
+    delay(100);
 }
-

--- a/examples/sensors/ultrasounds/SR04/SR04.ino
+++ b/examples/sensors/ultrasounds/SR04/SR04.ino
@@ -4,8 +4,8 @@ const int TRIGGER_PIN           = 6; // D6
 const int ECHO_PIN              = 7; // D7
 const unsigned int MAX_DISTANCE = 100;
 
-ArduinoRuntime arduino;
-SR04 front(arduino, TRIGGER_PIN, ECHO_PIN, MAX_DISTANCE);
+ArduinoRuntime arduinoRuntime;
+SR04 front(arduinoRuntime, TRIGGER_PIN, ECHO_PIN, MAX_DISTANCE);
 
 void setup()
 {

--- a/examples/sensors/ultrasounds/SRF08/SRF08.ino
+++ b/examples/sensors/ultrasounds/SRF08/SRF08.ino
@@ -4,8 +4,8 @@ const unsigned short GAIN        = 0x1F; // maximum gain
 const unsigned short RANGE       = 0x07; // 7 for 34 centimeters
 const unsigned short I2C_ADDRESS = 112;
 
-ArduinoRuntime arduino;
-SRF08 front(arduino, I2C_ADDRESS);
+ArduinoRuntime arduinoRuntime;
+SRF08 front(arduinoRuntime, I2C_ADDRESS);
 
 void setup()
 {

--- a/examples/sensors/ultrasounds/SRF08/SRF08.ino
+++ b/examples/sensors/ultrasounds/SRF08/SRF08.ino
@@ -1,18 +1,22 @@
 #include <Smartcar.h>
 
-const unsigned short GAIN = 0x1F; //maximum gain
-const unsigned short RANGE = 0x07; //7 for 34 centimeters
+const unsigned short GAIN        = 0x1F; // maximum gain
+const unsigned short RANGE       = 0x07; // 7 for 34 centimeters
 const unsigned short I2C_ADDRESS = 112;
-SRF08 front(I2C_ADDRESS);
 
-void setup() {
- // front.setGain(GAIN);
- // front.setRange(RANGE);
- // front.setPingDelay(8); //uncomment if u want to use custom measurement range
-  Serial.begin(9600);
+ArduinoRuntime arduino;
+SRF08 front(arduino, I2C_ADDRESS);
+
+void setup()
+{
+    // front.setGain(GAIN);
+    // front.setRange(RANGE);
+    // front.setPingDelay(8); // uncomment if u want to use custom measurement range
+    Serial.begin(9600);
 }
 
-void loop() {
-  Serial.print("Distance: ");
-  Serial.println(front.getDistance());
+void loop()
+{
+    Serial.print("Distance: ");
+    Serial.println(front.getDistance());
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Smartcar shield
-version=6.0.0
+version=7.0.0
 author=Dimitris Platis
 maintainer=Dimitris Platis <dimitris@plat.is>
 sentence=Arduino library for controlling the Smartcar platform

--- a/src/Smartcar.h
+++ b/src/Smartcar.h
@@ -7,18 +7,6 @@
  */
 #pragma once
 
-// We use this macro to specify that we are building for a board with an
-// Arduino-compatible API. This is done so the constructors of various classes
-// include the ArduinoRuntime instance that is defined below
-#define SMARTCAR_BUILD_FOR_ARDUINO
-#include "runtime/arduino_runtime/ArduinoRuntime.hpp"
-// Create an ArduinoRuntime instance to be used as a default argument in
-// many of the class constructors, so the users don't have to bother passing
-// it themselves.
-// In the future there might be built-in support for different runtime
-// environments but they will probably reside in separate header folders.
-ArduinoRuntime arduinoRuntime;
-
 #include "car/distance/DistanceCar.hpp"
 #include "car/heading/HeadingCar.hpp"
 #include "car/simple/SimpleCar.hpp"
@@ -27,6 +15,7 @@ ArduinoRuntime arduinoRuntime;
 #include "control/differential/DifferentialControl.hpp"
 #include "motor/analog/pwm/BrushedMotor.hpp"
 #include "motor/digital/servo/ServoMotor.hpp"
+#include "runtime/arduino_runtime/ArduinoRuntime.hpp"
 #include "sensors/distance/infrared/analog/sharp/GP2D120.hpp"
 #include "sensors/distance/infrared/analog/sharp/GP2Y0A02.hpp"
 #include "sensors/distance/infrared/analog/sharp/GP2Y0A21.hpp"

--- a/src/car/distance/DistanceCar.cpp
+++ b/src/car/distance/DistanceCar.cpp
@@ -14,7 +14,7 @@ using namespace smartcarlib::constants::car;
 using namespace smartcarlib::constants::control;
 using namespace smartcarlib::utils;
 
-DistanceCar::DistanceCar(Control& control, Odometer& odometer, Runtime& runtime)
+DistanceCar::DistanceCar(Runtime& runtime, Control& control, Odometer& odometer)
     : SimpleCar(control)
     , mOdometerLeft(odometer)
     , mOdometerRight(odometer)
@@ -22,10 +22,10 @@ DistanceCar::DistanceCar(Control& control, Odometer& odometer, Runtime& runtime)
 {
 }
 
-DistanceCar::DistanceCar(Control& control,
+DistanceCar::DistanceCar(Runtime& runtime,
+                         Control& control,
                          Odometer& odometerLeft,
-                         Odometer& odometerRight,
-                         Runtime& runtime)
+                         Odometer& odometerRight)
     : SimpleCar(control)
     , mOdometerLeft(odometerLeft)
     , mOdometerRight(odometerRight)

--- a/src/car/distance/DistanceCar.hpp
+++ b/src/car/distance/DistanceCar.hpp
@@ -8,11 +8,6 @@
 #include "../../sensors/odometer/Odometer.hpp"
 #include "../simple/SimpleCar.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 namespace smartcarlib
 {
 namespace constants
@@ -32,28 +27,31 @@ const auto kBreakSpeedScale              = 10;
 class DistanceCar : virtual public SimpleCar
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs a car equipped with a distance sensor
+     * @param runtime  The runtime environment you want to run the class for
      * @param control  The car's control
      * @param odometer The odometer
      *
      * **Example:**
      * \code
-     * BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-     * BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+     * ArduinoRuntime arduino;
+     * BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+     * BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
      * DifferentialControl control(leftMotor, rightMotor);
      *
-     * DirectionlessOdometer odometer(100);
+     * DirectionlessOdometer odometer(
+     *   arduino, smartcarlib::pins::v2::leftOdometerPin, []() { odometer.update(); }, 100);
 
-     * DistanceCar car(control, odometer);
+     * DistanceCar car(arduino, control, odometer);
      * \endcode
      */
-    DistanceCar(Control& control, Odometer& odometer, Runtime& runtime = arduinoRuntime);
+    DistanceCar(Runtime& runtime, Control& control, Odometer& odometer);
 
     /**
      * Constructs a car equipped with a distance sensor
-     * @param control        The car's control
+     * @param runtime       The runtime environment you want to run the class for
+     * @param control       The car's control
      * @param odometerLeft  The left odometer
      * @param odometerRight The right odometer
      *
@@ -74,17 +72,10 @@ public:
      * DistanceCar car(control, gyroscope, leftOdometer, rightOdometer);
      * \endcode
      */
-    DistanceCar(Control& control,
+    DistanceCar(Runtime& runtime,
+                Control& control,
                 Odometer& odometerLeft,
-                Odometer& odometerRight,
-                Runtime& runtime = arduinoRuntime);
-#else
-    DistanceCar(Control& control, Odometer& odometer, Runtime& runtime);
-    DistanceCar(Control& control,
-                Odometer& odometerLeft,
-                Odometer& odometerRight,
-                Runtime& runtime);
-#endif
+                Odometer& odometerRight);
 
     /**
      * Gets the car's travelled distance

--- a/src/car/distance/DistanceCar.hpp
+++ b/src/car/distance/DistanceCar.hpp
@@ -35,15 +35,15 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
-     * BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-     * BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+     * ArduinoRuntime arduinoRuntime;
+     * BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+     * BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
      * DifferentialControl control(leftMotor, rightMotor);
      *
      * DirectionlessOdometer odometer(
-     *   arduino, smartcarlib::pins::v2::leftOdometerPin, []() { odometer.update(); }, 100);
+     *   arduinoRuntime, smartcarlib::pins::v2::leftOdometerPin, []() { odometer.update(); }, 100);
 
-     * DistanceCar car(arduino, control, odometer);
+     * DistanceCar car(arduinoRuntime, control, odometer);
      * \endcode
      */
     DistanceCar(Runtime& runtime, Control& control, Odometer& odometer);

--- a/src/car/smart/SmartCar.cpp
+++ b/src/car/smart/SmartCar.cpp
@@ -1,22 +1,22 @@
 #include "SmartCar.hpp"
 
-SmartCar::SmartCar(Control& control,
+SmartCar::SmartCar(Runtime& runtime,
+                   Control& control,
                    HeadingSensor& headingSensor,
-                   Odometer& odometer,
-                   Runtime& runtime)
+                   Odometer& odometer)
     : SimpleCar::SimpleCar(control)
-    , DistanceCar::DistanceCar(control, odometer, runtime)
+    , DistanceCar::DistanceCar(runtime, control, odometer)
     , HeadingCar::HeadingCar(control, headingSensor)
 {
 }
 
-SmartCar::SmartCar(Control& control,
+SmartCar::SmartCar(Runtime& runtime,
+                   Control& control,
                    HeadingSensor& headingSensor,
                    Odometer& odometerleft,
-                   Odometer& odometerRight,
-                   Runtime& runtime)
+                   Odometer& odometerRight)
     : SimpleCar::SimpleCar(control)
-    , DistanceCar::DistanceCar(control, odometerleft, odometerRight, runtime)
+    , DistanceCar::DistanceCar(runtime, control, odometerleft, odometerRight)
     , HeadingCar::HeadingCar(control, headingSensor)
 {
 }

--- a/src/car/smart/SmartCar.hpp
+++ b/src/car/smart/SmartCar.hpp
@@ -20,20 +20,20 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
-     * BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-     * BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+     * ArduinoRuntime arduinoRuntime;
+     * BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+     * BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
      * DifferentialControl control(leftMotor, rightMotor);
      *
-     * GY50 gyroscope(arduino, 37);
+     * GY50 gyroscope(arduinoRuntime, 37);
      *
      * const auto pulsesPerMeter = 600;
      *
      * DirectionlessOdometer odometer(
-     *     arduino, smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); },
+     *     arduinoRuntime, smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); },
      *     pulsesPerMeter);
      *
-     * SmartCar car(arduino, control, gyroscope, odometer);
+     * SmartCar car(arduinoRuntime, control, gyroscope, odometer);
      * \endcode
      */
     SmartCar(Runtime& runtime, Control& control, HeadingSensor& headingSensor, Odometer& odometer);
@@ -48,23 +48,23 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
-     * BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
-     * BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
+     * ArduinoRuntime arduinoRuntime;
+     * BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
+     * BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
      * DifferentialControl control(leftMotor, rightMotor);
      *
-     * GY50 gyroscope(arduino, 37);
+     * GY50 gyroscope(arduinoRuntime, 37);
      *
      * const auto pulsesPerMeter = 600;
      *
      * DirectionlessOdometer leftOdometer(
-     *     arduino, smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); },
+     *     arduinoRuntime, smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); },
      *     pulsesPerMeter);
      * DirectionlessOdometer rightOdometer(
-     *     arduino, smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); },
-     *     pulsesPerMeter);
+     *     arduinoRuntime, smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update();
+     * }, pulsesPerMeter);
      *
-     * SmartCar car(arduino, control, gyroscope, leftOdometer, rightOdometer);
+     * SmartCar car(arduinoRuntime, control, gyroscope, leftOdometer, rightOdometer);
      * \endcode
      */
     SmartCar(Runtime& runtime,

--- a/src/car/smart/SmartCar.hpp
+++ b/src/car/smart/SmartCar.hpp
@@ -8,40 +8,39 @@
 #include "../distance/DistanceCar.hpp"
 #include "../heading/HeadingCar.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 class SmartCar : public DistanceCar, public HeadingCar
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs a car equipped with a heading sensor and an odometer
+     * @param runtime        The runtime environment you want to run the class for
      * @param control        The car's control
      * @param headingSensor  The heading sensor
      * @param odometer       The odometer
      *
      * **Example:**
      * \code
-     * BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-     * BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+     * ArduinoRuntime arduino;
+     * BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+     * BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
      * DifferentialControl control(leftMotor, rightMotor);
      *
-     * GY50 gyroscope(37);
-     * DirectionlessOdometer odometer(100);
-
-     * SmartCar car(control, gyroscope, odometer);
+     * GY50 gyroscope(arduino, 37);
+     *
+     * const auto pulsesPerMeter = 600;
+     *
+     * DirectionlessOdometer odometer(
+     *     arduino, smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); },
+     *     pulsesPerMeter);
+     *
+     * SmartCar car(arduino, control, gyroscope, odometer);
      * \endcode
      */
-    SmartCar(Control& control,
-             HeadingSensor& headingSensor,
-             Odometer& odometer,
-             Runtime& runtime = arduinoRuntime);
+    SmartCar(Runtime& runtime, Control& control, HeadingSensor& headingSensor, Odometer& odometer);
 
     /**
      * Constructs a car equipped with a heading sensor and two odometers
+     * @param runtime       The runtime environment you want to run the class for
      * @param control       The car's control
      * @param headingSensor The heading sensor
      * @param odometerLeft  The left odometer
@@ -49,36 +48,30 @@ public:
      *
      * **Example:**
      * \code
-     * BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
-     * BrushedMotor rightMotor(smartcarlib::pins::v2::rightMotorPins);
+     * ArduinoRuntime arduino;
+     * BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+     * BrushedMotor rightMotor(arduino, smartcarlib::pins::v2::rightMotorPins);
      * DifferentialControl control(leftMotor, rightMotor);
      *
-     * GY50 gyroscope(37);
+     * GY50 gyroscope(arduino, 37);
      *
      * const auto pulsesPerMeter = 600;
      *
      * DirectionlessOdometer leftOdometer(
-     *     smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); }, pulsesPerMeter);
+     *     arduino, smartcarlib::pins::v2::leftOdometerPin, []() { leftOdometer.update(); },
+     *     pulsesPerMeter);
      * DirectionlessOdometer rightOdometer(
-     *     smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); },
+     *     arduino, smartcarlib::pins::v2::rightOdometerPin, []() { rightOdometer.update(); },
      *     pulsesPerMeter);
      *
-     * SmartCar car(control, gyroscope, leftOdometer, rightOdometer);
+     * SmartCar car(arduino, control, gyroscope, leftOdometer, rightOdometer);
      * \endcode
      */
-    SmartCar(Control& control,
+    SmartCar(Runtime& runtime,
+             Control& control,
              HeadingSensor& headingSensor,
              Odometer& odometerLeft,
-             Odometer& odometerRight,
-             Runtime& runtime = arduinoRuntime);
-#else
-    SmartCar(Control& control, HeadingSensor& headingSensor, Odometer& odometer, Runtime& runtime);
-    SmartCar(Control& control,
-             HeadingSensor& headingSensor,
-             Odometer& odometerLeft,
-             Odometer& odometerRight,
-             Runtime& runtime);
-#endif
+             Odometer& odometerRight);
 
     /**
      * Adjusts the speed when cruise control is enabled and calculates the current heading.

--- a/src/motor/analog/pwm/BrushedMotor.cpp
+++ b/src/motor/analog/pwm/BrushedMotor.cpp
@@ -10,10 +10,10 @@ const int kMaxPwm = 255;
 using namespace smartcarlib::utils;
 using namespace smartcarlib::constants::motor;
 
-BrushedMotor::BrushedMotor(uint8_t forwardPin,
+BrushedMotor::BrushedMotor(Runtime& runtime,
+                           uint8_t forwardPin,
                            uint8_t backwardPin,
-                           uint8_t enablePin,
-                           Runtime& runtime)
+                           uint8_t enablePin)
     : kForwardPin{ forwardPin }
     , kBackwardPin{ backwardPin }
     , kEnablePin{ enablePin }
@@ -24,8 +24,8 @@ BrushedMotor::BrushedMotor(uint8_t forwardPin,
 {
 }
 
-BrushedMotor::BrushedMotor(BrushedMotorPins pins, Runtime& runtime)
-    : BrushedMotor{ pins.forward, pins.backward, pins.enable, runtime }
+BrushedMotor::BrushedMotor(Runtime& runtime, BrushedMotorPins pins)
+    : BrushedMotor{ runtime, pins.forward, pins.backward, pins.enable }
 {
 }
 

--- a/src/motor/analog/pwm/BrushedMotor.hpp
+++ b/src/motor/analog/pwm/BrushedMotor.hpp
@@ -14,11 +14,6 @@
 #include "../../../runtime/Runtime.hpp"
 #include "../../Motor.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 /**
  * @brief Helper class to represent brushed motor pins
  */
@@ -46,38 +41,33 @@ struct BrushedMotorPins
 class BrushedMotor : public Motor
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs a brushed DC motor instance
+     * @param runtime     The runtime environment you want to run the class for
      * @param forwardPin  The direction pin that when set to HIGH makes the motor spin forward
      * @param backwardPin The direction pin that when set to HIGH makes the motor spin forward
      * @param enablePin   The pin  that controls the motor's speed
      *
      * **Example:**
      * \code
-     * BrushedMotor leftMotor(8, 9, 10);
+     * ArduinoRuntime arduino;
+     * BrushedMotor leftMotor(arduino, 8, 9, 10);
      * \endcode
      */
-    BrushedMotor(uint8_t forwardPin,
-                 uint8_t backwardPin,
-                 uint8_t enablePin,
-                 Runtime& runtime = arduinoRuntime);
+    BrushedMotor(Runtime& runtime, uint8_t forwardPin, uint8_t backwardPin, uint8_t enablePin);
 
     /**
      * Constructs a brushed DC motor instance
-     * @param pins  The `BrushedMotorPins` object with the pins of the motor
+     * @param runtime The runtime environment you want to run the class for
+     * @param pins    The `BrushedMotorPins` object with the pins of the motor
      *
      * **Example:**
      * \code
-     * BrushedMotor leftMotor(smartcarlib::pins::v2::leftMotorPins);
+     * ArduinoRuntime arduino;
+     * BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
      * \endcode
      */
-    BrushedMotor(BrushedMotorPins pins, Runtime& runtime = arduinoRuntime);
-
-#else
-    BrushedMotor(uint8_t forwardPin, uint8_t backwardPin, uint8_t enablePin, Runtime& runtime);
-    BrushedMotor(BrushedMotorPins pins, Runtime& runtime);
-#endif
+    BrushedMotor(Runtime& runtime, BrushedMotorPins pins);
 
     /* Check `Motor` interface for documentation */
     void setSpeed(int speed) override;

--- a/src/motor/analog/pwm/BrushedMotor.hpp
+++ b/src/motor/analog/pwm/BrushedMotor.hpp
@@ -50,8 +50,8 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
-     * BrushedMotor leftMotor(arduino, 8, 9, 10);
+     * ArduinoRuntime arduinoRuntime;
+     * BrushedMotor leftMotor(arduinoRuntime, 8, 9, 10);
      * \endcode
      */
     BrushedMotor(Runtime& runtime, uint8_t forwardPin, uint8_t backwardPin, uint8_t enablePin);
@@ -63,8 +63,8 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
-     * BrushedMotor leftMotor(arduino, smartcarlib::pins::v2::leftMotorPins);
+     * ArduinoRuntime arduinoRuntime;
+     * BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
      * \endcode
      */
     BrushedMotor(Runtime& runtime, BrushedMotorPins pins);

--- a/src/sensors/distance/infrared/analog/sharp/GP2D120.cpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2D120.cpp
@@ -6,7 +6,7 @@ const auto kMinDistance = 5;  // GP2D120's minimum distance
 const auto kMaxDistance = 25; // GP2D120's maximum distance
 } // namespace
 
-GP2D120::GP2D120(uint8_t pin, Runtime& runtime)
+GP2D120::GP2D120(Runtime& runtime, uint8_t pin)
     : InfraredAnalogSensor(runtime)
     , kPin{ pin }
     , mRuntime(runtime)

--- a/src/sensors/distance/infrared/analog/sharp/GP2D120.hpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2D120.hpp
@@ -18,9 +18,9 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
+     * ArduinoRuntime arduinoRuntime;
      * const unsigned short IR_PIN = A1;
-     * GP2D120 infraredSensor(arduino, IR_PIN);
+     * GP2D120 infraredSensor(arduinoRuntime, IR_PIN);
      * \endcode
      */
     GP2D120(Runtime& runtime, uint8_t pin);

--- a/src/sensors/distance/infrared/analog/sharp/GP2D120.hpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2D120.hpp
@@ -8,29 +8,22 @@
 #include "../../../../../runtime/Runtime.hpp"
 #include "../InfraredAnalogSensor.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../../../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 class GP2D120 : public InfraredAnalogSensor
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs a GP2D120 sensor
-     * @param pin   The analog pin receiving sensor signals
+     * @param runtime The runtime environment you want to run the class for
+     * @param pin     The analog pin receiving sensor signals
      *
      * **Example:**
      * \code
+     * ArduinoRuntime arduino;
      * const unsigned short IR_PIN = A1;
-     * GP2D120 infraredSensor(IR_PIN);
+     * GP2D120 infraredSensor(arduino, IR_PIN);
      * \endcode
      */
-    GP2D120(uint8_t pin, Runtime& runtime = arduinoRuntime);
-#else
-    GP2D120(uint8_t pin, Runtime& runtime);
-#endif
+    GP2D120(Runtime& runtime, uint8_t pin);
 
     /* Check `DistanceSensor` interface for documentation */
     unsigned int getDistance() override;
@@ -41,6 +34,6 @@ private:
 };
 
 /**
-* \example GP2D120.ino
-* A basic example on how to get a distance measurement from a GP2D120 infrared sensor.
-*/
+ * \example GP2D120.ino
+ * A basic example on how to get a distance measurement from a GP2D120 infrared sensor.
+ */

--- a/src/sensors/distance/infrared/analog/sharp/GP2Y0A02.cpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2Y0A02.cpp
@@ -6,7 +6,7 @@ const auto kMinDistance = 25;  // GP2Y0A02's minimum distance
 const auto kMaxDistance = 120; // GP2Y0A02's maximum distance
 } // namespace
 
-GP2Y0A02::GP2Y0A02(uint8_t pin, Runtime& runtime)
+GP2Y0A02::GP2Y0A02(Runtime& runtime, uint8_t pin)
     : InfraredAnalogSensor(runtime)
     , kPin{ pin }
     , mRuntime(runtime)

--- a/src/sensors/distance/infrared/analog/sharp/GP2Y0A02.hpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2Y0A02.hpp
@@ -8,29 +8,22 @@
 #include "../../../../../runtime/Runtime.hpp"
 #include "../InfraredAnalogSensor.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../../../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 class GP2Y0A02 : public InfraredAnalogSensor
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs a GP2Y0A02 sensor
-     * @param pin   The analog pin receiving sensor signals
+     * @param runtime The runtime environment you want to run the class for
+     * @param pin     The analog pin receiving sensor signals
      *
      * **Example:**
      * \code
+     * ArduinoRuntime arduino,
      * const unsigned short IR_PIN = A1;
-     * GP2Y0A02 infraredSensor(IR_PIN);
+     * GP2Y0A02 infraredSensor(arduino, IR_PIN);
      * \endcode
      */
-    GP2Y0A02(uint8_t pin, Runtime& runtime = arduinoRuntime);
-#else
-    GP2Y0A02(uint8_t pin, Runtime& runtime);
-#endif
+    GP2Y0A02(Runtime& runtime, uint8_t pin);
 
     /* Check `DistanceSensor` interface for documentation */
     unsigned int getDistance() override;
@@ -41,6 +34,6 @@ private:
 };
 
 /**
-* \example GP2Y0A02.ino
-* A basic example on how to get a distance measurement from a GP2Y0A02 infrared sensor.
-*/
+ * \example GP2Y0A02.ino
+ * A basic example on how to get a distance measurement from a GP2Y0A02 infrared sensor.
+ */

--- a/src/sensors/distance/infrared/analog/sharp/GP2Y0A02.hpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2Y0A02.hpp
@@ -18,9 +18,9 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino,
+     * ArduinoRuntime arduinoRuntime,
      * const unsigned short IR_PIN = A1;
-     * GP2Y0A02 infraredSensor(arduino, IR_PIN);
+     * GP2Y0A02 infraredSensor(arduinoRuntime, IR_PIN);
      * \endcode
      */
     GP2Y0A02(Runtime& runtime, uint8_t pin);

--- a/src/sensors/distance/infrared/analog/sharp/GP2Y0A21.cpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2Y0A21.cpp
@@ -6,7 +6,7 @@ const auto kMinDistance = 12; // GP2Y0A21's minimum distance
 const auto kMaxDistance = 78; // GP2Y0A21's maximum distance
 } // namespace
 
-GP2Y0A21::GP2Y0A21(uint8_t pin, Runtime& runtime)
+GP2Y0A21::GP2Y0A21(Runtime& runtime, uint8_t pin)
     : InfraredAnalogSensor(runtime)
     , kPin{ pin }
     , mRuntime(runtime)

--- a/src/sensors/distance/infrared/analog/sharp/GP2Y0A21.hpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2Y0A21.hpp
@@ -18,9 +18,9 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
+     * ArduinoRuntime arduinoRuntime;
      * const unsigned short IR_PIN = A1;
-     * GP2Y0A21 infraredSensor(arduino, IR_PIN);
+     * GP2Y0A21 infraredSensor(arduinoRuntime, IR_PIN);
      * \endcode
      */
     GP2Y0A21(Runtime& runtime, uint8_t pin);

--- a/src/sensors/distance/infrared/analog/sharp/GP2Y0A21.hpp
+++ b/src/sensors/distance/infrared/analog/sharp/GP2Y0A21.hpp
@@ -8,29 +8,22 @@
 #include "../../../../../runtime/Runtime.hpp"
 #include "../InfraredAnalogSensor.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../../../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 class GP2Y0A21 : public InfraredAnalogSensor
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs a GP2Y0A21 sensor
-     * @param pin   The analog pin receiving sensor signals
+     * @param runtime The runtime environment you want to run the class for
+     * @param pin     The analog pin receiving sensor signals
      *
      * **Example:**
      * \code
+     * ArduinoRuntime arduino;
      * const unsigned short IR_PIN = A1;
-     * GP2Y0A21 infraredSensor(IR_PIN);
+     * GP2Y0A21 infraredSensor(arduino, IR_PIN);
      * \endcode
      */
-    GP2Y0A21(uint8_t pin, Runtime& runtime = arduinoRuntime);
-#else
-    GP2Y0A21(uint8_t pin, Runtime& runtime);
-#endif
+    GP2Y0A21(Runtime& runtime, uint8_t pin);
 
     /* Check `DistanceSensor` interface for documentation */
     unsigned int getDistance() override;
@@ -41,6 +34,6 @@ private:
 };
 
 /**
-* \example GP2Y0A21.ino
-* A basic example on how to get a distance measurement from a GP2Y0A21 infrared sensor.
-*/
+ * \example GP2Y0A21.ino
+ * A basic example on how to get a distance measurement from a GP2Y0A21 infrared sensor.
+ */

--- a/src/sensors/distance/ultrasound/i2c/SRF08.cpp
+++ b/src/sensors/distance/ultrasound/i2c/SRF08.cpp
@@ -15,7 +15,7 @@ using namespace smartcarlib::constants::srf08;
 using namespace smartcarlib::constants::distanceSensor;
 using namespace smartcarlib::utils;
 
-SRF08::SRF08(uint8_t address, Runtime& runtime)
+SRF08::SRF08(Runtime& runtime, uint8_t address)
     : mAddress{ address }
     , mRuntime(runtime)
     , mPingDelay{ kDefaultPingDelay }

--- a/src/sensors/distance/ultrasound/i2c/SRF08.hpp
+++ b/src/sensors/distance/ultrasound/i2c/SRF08.hpp
@@ -33,8 +33,8 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
-     * SRF08 srf08(arduino, 112);
+     * ArduinoRuntime arduinoRuntime;
+     * SRF08 srf08(arduinoRuntime, 112);
      * \endcode
      */
     SRF08(Runtime& runtime, uint8_t address);

--- a/src/sensors/distance/ultrasound/i2c/SRF08.hpp
+++ b/src/sensors/distance/ultrasound/i2c/SRF08.hpp
@@ -11,11 +11,6 @@
 #include "../../../../runtime/Runtime.hpp"
 #include "../../DistanceSensor.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 namespace smartcarlib
 {
 namespace constants
@@ -31,20 +26,18 @@ const uint8_t kDefaultPingDelay  = 70;
 class SRF08 : public DistanceSensor
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs an SRF08 sensor that communicates over I2C
+     * @param runtime The runtime environment you want to run the class for
      * @param address I2C address which should be within the range of [112, 127]
      *
      * **Example:**
      * \code
-     * SRF08 srf08(112);
+     * ArduinoRuntime arduino;
+     * SRF08 srf08(arduino, 112);
      * \endcode
      */
-    SRF08(uint8_t address, Runtime& runtime = arduinoRuntime);
-#else
-    SRF08(uint8_t address, Runtime& runtime);
-#endif
+    SRF08(Runtime& runtime, uint8_t address);
 
     /* Check `DistanceSensor` interface for documentation */
     unsigned int getDistance() override;

--- a/src/sensors/distance/ultrasound/ping/SR04.cpp
+++ b/src/sensors/distance/ultrasound/ping/SR04.cpp
@@ -13,7 +13,7 @@ using namespace smartcarlib::constants::sr04;
 using namespace smartcarlib::constants::distanceSensor;
 using namespace smartcarlib::utils;
 
-SR04::SR04(uint8_t triggerPin, uint8_t echoPin, unsigned int maxDistance, Runtime& runtime)
+SR04::SR04(Runtime& runtime, uint8_t triggerPin, uint8_t echoPin, unsigned int maxDistance)
     : kTriggerPin{ triggerPin }
     , kEchoPin{ echoPin }
     , kMaxDistance{ maxDistance > 0 ? maxDistance : kDefaultMaxDistance }

--- a/src/sensors/distance/ultrasound/ping/SR04.hpp
+++ b/src/sensors/distance/ultrasound/ping/SR04.hpp
@@ -41,8 +41,8 @@ public:
      * unsigned short TRIGGER_PIN = 6;
      * unsigned short ECHO_PIN = 7;
      *
-     * ArduinoRuntime arduino;
-     * SR04 sr04(arduino, TRIGGER_PIN, ECHO_PIN);
+     * ArduinoRuntime arduinoRuntime;
+     * SR04 sr04(arduinoRuntime, TRIGGER_PIN, ECHO_PIN);
      * \endcode
      */
     SR04(Runtime& runtime,

--- a/src/sensors/distance/ultrasound/ping/SR04.hpp
+++ b/src/sensors/distance/ultrasound/ping/SR04.hpp
@@ -13,11 +13,6 @@
 #include "../../../../runtime/Runtime.hpp"
 #include "../../DistanceSensor.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 namespace smartcarlib
 {
 namespace constants
@@ -34,9 +29,9 @@ const unsigned int kError              = 0;
 class SR04 : public DistanceSensor
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs an SR04 ultrasonic sensor
+     * @param runtime     The runtime environment you want to run the class for
      * @param triggerPin  The pin to produce the trigger signal
      * @param echoPin     The pin to receive the echo signal
      * @param maxDistance The maximum measurement distance in centimeters
@@ -46,16 +41,14 @@ public:
      * unsigned short TRIGGER_PIN = 6;
      * unsigned short ECHO_PIN = 7;
      *
-     * SR04 sr04(TRIGGER_PIN, ECHO_PIN);
+     * ArduinoRuntime arduino;
+     * SR04 sr04(arduino, TRIGGER_PIN, ECHO_PIN);
      * \endcode
      */
-    SR04(uint8_t triggerPin,
+    SR04(Runtime& runtime,
+         uint8_t triggerPin,
          uint8_t echoPin,
-         unsigned int maxDistance = smartcarlib::constants::sr04::kDefaultMaxDistance,
-         Runtime& runtime         = arduinoRuntime);
-#else
-    SR04(uint8_t triggerPin, uint8_t echoPin, unsigned int maxDistance, Runtime& runtime);
-#endif
+         unsigned int maxDistance = smartcarlib::constants::sr04::kDefaultMaxDistance);
 
     /* Check `DistanceSensor` interface for documentation */
     unsigned int getDistance() override;

--- a/src/sensors/heading/gyroscope/GY50.cpp
+++ b/src/sensors/heading/gyroscope/GY50.cpp
@@ -18,7 +18,7 @@ const int kGyroThreshold        = 12; // Smaller changes are to be ignored
 using namespace smartcarlib::utils;
 using namespace smartcarlib::constants::gy50;
 
-GY50::GY50(int offset, unsigned long samplingInterval, Runtime& runtime)
+GY50::GY50(Runtime& runtime, int offset, unsigned long samplingInterval)
     : kOffset{ offset }
     , kSamplingInterval{ samplingInterval }
     , mRuntime(runtime)

--- a/src/sensors/heading/gyroscope/GY50.hpp
+++ b/src/sensors/heading/gyroscope/GY50.hpp
@@ -42,9 +42,9 @@ public:
      *
      * **Example:**
      * \code
-     * ArduinoRuntime arduino;
+     * ArduinoRuntime arduinoRuntime;
      * int offset = 37; // The offset we have acquired via the getOffset method
-     * GY50 gyro(arduino, offset);
+     * GY50 gyro(arduinoRuntime, offset);
      * \endcode
      */
     GY50(Runtime& runtime,

--- a/src/sensors/heading/gyroscope/GY50.hpp
+++ b/src/sensors/heading/gyroscope/GY50.hpp
@@ -17,11 +17,6 @@
 #include "../../../runtime/Runtime.hpp"
 #include "../HeadingSensor.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 namespace smartcarlib
 {
 namespace constants
@@ -38,25 +33,23 @@ const int kDefaultCalibrationMeasurements = 100;
 class GY50 : public HeadingSensor
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs a GY50 gyroscope
+     * @param runtime          The runtime environment you want to run the class for
      * @param offset           The sensor-specific measurement value when idle.
      *                         Find the value for your sensing with GY50::getOffset.
      * @param samplingInterval How often to upate the heading
      *
      * **Example:**
      * \code
+     * ArduinoRuntime arduino;
      * int offset = 37; // The offset we have acquired via the getOffset method
-     * GY50 gyro(offset);
+     * GY50 gyro(arduino, offset);
      * \endcode
      */
-    GY50(int offset,
-         unsigned long samplingInterval = smartcarlib::constants::gy50::kDefaultSamplingInterval,
-         Runtime& runtime               = arduinoRuntime);
-#else
-    GY50(int offset, unsigned long samplingInterval, Runtime& runtime);
-#endif
+    GY50(Runtime& runtime,
+         int offset,
+         unsigned long samplingInterval = smartcarlib::constants::gy50::kDefaultSamplingInterval);
 
     /* Check `HeadingSensor` interface for documentation */
     int getHeading() override;

--- a/src/sensors/odometer/interrupt/DirectionalOdometer.cpp
+++ b/src/sensors/odometer/interrupt/DirectionalOdometer.cpp
@@ -8,12 +8,12 @@ namespace
 const auto kInvalidPinState = INT_MIN;
 }
 
-DirectionalOdometer::DirectionalOdometer(uint8_t pulsePin,
+DirectionalOdometer::DirectionalOdometer(Runtime& runtime,
+                                         uint8_t pulsePin,
                                          uint8_t forwardWhenLowPin,
                                          InterruptCallback callback,
-                                         unsigned long pulsesPerMeter,
-                                         Runtime& runtime)
-    : DirectionlessOdometer(pulsePin, callback, pulsesPerMeter, runtime)
+                                         unsigned long pulsesPerMeter)
+    : DirectionlessOdometer(runtime, pulsePin, callback, pulsesPerMeter)
     , mDirectionPin{ forwardWhenLowPin }
     , mRuntime(runtime)
     , kPinStateWhenForward{ mRuntime.getLowState() }
@@ -22,11 +22,11 @@ DirectionalOdometer::DirectionalOdometer(uint8_t pulsePin,
     mRuntime.setPinDirection(mDirectionPin, mRuntime.getInputState());
 }
 
-DirectionalOdometer::DirectionalOdometer(DirectionalOdometerPins pins,
+DirectionalOdometer::DirectionalOdometer(Runtime& runtime,
+                                         DirectionalOdometerPins pins,
                                          InterruptCallback callback,
-                                         unsigned long pulsesPerMeter,
-                                         Runtime& runtime)
-    : DirectionalOdometer(pins.pulse, pins.direction, callback, pulsesPerMeter, runtime)
+                                         unsigned long pulsesPerMeter)
+    : DirectionalOdometer(runtime, pins.pulse, pins.direction, callback, pulsesPerMeter)
 {
 }
 

--- a/src/sensors/odometer/interrupt/DirectionalOdometer.hpp
+++ b/src/sensors/odometer/interrupt/DirectionalOdometer.hpp
@@ -45,9 +45,9 @@ public:
      * unsigned short ODOMETER_PIN = 32;
      * unsigned short DIRECTION_PIN = 8;
      * unsigned long PULSES_PER_METER = 40;
-     * ArduinoRuntime arduino;
+     * ArduinoRuntime arduinoRuntime;
      *
-     * DirectionalOdometer odometer(arduino,
+     * DirectionalOdometer odometer(arduinoRuntime,
      *                              ODOMETER_PIN,
      *                              DIRECTION_PIN,
      *                              []() { odometer.update(); },
@@ -69,9 +69,9 @@ public:
      * **Example:**
      * \code
      * unsigned long PULSES_PER_METER = 40;
-     * ArduinoRuntime arduino;
+     * ArduinoRuntime arduinoRuntime;
      *
-     * DirectionalOdometer leftOdometer(arduino,
+     * DirectionalOdometer leftOdometer(arduinoRuntime,
      *                                  smartcarlib::pins::v2::leftOdometerPins,
      *                                  []() { odometer.update(); },
      *                                  PULSES_PER_METER);

--- a/src/sensors/odometer/interrupt/DirectionalOdometer.hpp
+++ b/src/sensors/odometer/interrupt/DirectionalOdometer.hpp
@@ -32,9 +32,9 @@ struct DirectionalOdometerPins
 class DirectionalOdometer : public DirectionlessOdometer
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs an odometer that can measure distance, speed and direction
+     * @param runtime           The runtime environment you want to run the class for
      * @param pulsePin          The pin that receives the pulses
      * @param forwardWhenLowPin The pin that is set to LOW when moving forward
      * @param callback          The callback to be invoked when a pulse is received (see example)
@@ -45,18 +45,20 @@ public:
      * unsigned short ODOMETER_PIN = 32;
      * unsigned short DIRECTION_PIN = 8;
      * unsigned long PULSES_PER_METER = 40;
+     * ArduinoRuntime arduino;
      *
-     * DirectionalOdometer odometer(ODOMETER_PIN,
+     * DirectionalOdometer odometer(arduino,
+     *                              ODOMETER_PIN,
      *                              DIRECTION_PIN,
      *                              []() { odometer.update(); },
      *                              PULSES_PER_METER);
      * \endcode
      */
-    DirectionalOdometer(uint8_t pulsePin,
+    DirectionalOdometer(Runtime& runtime,
+                        uint8_t pulsePin,
                         uint8_t forwardWhenLowPin,
                         InterruptCallback callback,
-                        unsigned long pulsesPerMeter,
-                        Runtime& runtime = arduinoRuntime);
+                        unsigned long pulsesPerMeter);
 
     /**
      * Constructs an odometer that can measure distance, speed and direction
@@ -67,28 +69,18 @@ public:
      * **Example:**
      * \code
      * unsigned long PULSES_PER_METER = 40;
+     * ArduinoRuntime arduino;
      *
-     * DirectionalOdometer leftOdometer(smartcarlib::pins::v2::leftOdometerPins,
+     * DirectionalOdometer leftOdometer(arduino,
+     *                                  smartcarlib::pins::v2::leftOdometerPins,
      *                                  []() { odometer.update(); },
      *                                  PULSES_PER_METER);
      * \endcode
      */
-    DirectionalOdometer(DirectionalOdometerPins pins,
+    DirectionalOdometer(Runtime& runtime,
+                        DirectionalOdometerPins pins,
                         InterruptCallback callback,
-                        unsigned long pulsesPerMeter,
-                        Runtime& runtime = arduinoRuntime);
-#else
-    DirectionalOdometer(uint8_t pulsePin,
-                        uint8_t forwardWhenLowPin,
-                        InterruptCallback callback,
-                        unsigned long pulsesPerMeter,
-                        Runtime& runtime);
-
-    DirectionalOdometer(DirectionalOdometerPins pins,
-                        InterruptCallback callback,
-                        unsigned long pulsesPerMeter,
-                        Runtime& runtime);
-#endif
+                        unsigned long pulsesPerMeter);
 
     /* Check `DirectionlessOdometer` for documentation */
     void reset() override;

--- a/src/sensors/odometer/interrupt/DirectionlessOdometer.cpp
+++ b/src/sensors/odometer/interrupt/DirectionlessOdometer.cpp
@@ -11,10 +11,10 @@ const float kMillimetersInMeter   = 1000.0;
 
 using namespace smartcarlib::constants::odometer;
 
-DirectionlessOdometer::DirectionlessOdometer(uint8_t pulsePin,
+DirectionlessOdometer::DirectionlessOdometer(Runtime& runtime,
+                                             uint8_t pulsePin,
                                              InterruptCallback callback,
-                                             unsigned long pulsesPerMeter,
-                                             Runtime& runtime)
+                                             unsigned long pulsesPerMeter)
     : mPulsesPerMeterRatio{ pulsesPerMeter > 0 ? static_cast<float>(pulsesPerMeter) / 100.0f
                                                : kDefaultPulsesPerMeter / 100.0f }
     , mMillimetersPerPulse{ pulsesPerMeter > 0

--- a/src/sensors/odometer/interrupt/DirectionlessOdometer.hpp
+++ b/src/sensors/odometer/interrupt/DirectionlessOdometer.hpp
@@ -25,9 +25,9 @@ public:
      * \code
      * unsigned short ODOMETER_PIN = 32;
      * unsigned long PULSES_PER_METER = 110;
-     * ArduinoRuntime arduino;
+     * ArduinoRuntime arduinoRuntime;
      *
-     * DirectionlessOdometer odometer(arduino,
+     * DirectionlessOdometer odometer(arduinoRuntime,
      *                                ODOMETER_PIN,
      *                                []() { odometer.update(); },
      *                                PULSES_PER_METER);

--- a/src/sensors/odometer/interrupt/DirectionlessOdometer.hpp
+++ b/src/sensors/odometer/interrupt/DirectionlessOdometer.hpp
@@ -11,17 +11,12 @@
 #include "../../../runtime/Runtime.hpp"
 #include "../Odometer.hpp"
 
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
-#include "../../../runtime/arduino_runtime/ArduinoRuntime.hpp"
-extern ArduinoRuntime arduinoRuntime;
-#endif
-
 class DirectionlessOdometer : public Odometer
 {
 public:
-#ifdef SMARTCAR_BUILD_FOR_ARDUINO
     /**
      * Constructs an odometer that can measure distance, speed but not direction
+     * @param runtime           The runtime environment you want to run the class for
      * @param pulsePin          The pin that receives the pulses
      * @param callback          The callback to be invoked when a pulse is received (see example)
      * @param pulsesPerMeter    The amount of odometer pulses that constitute a meter
@@ -30,22 +25,18 @@ public:
      * \code
      * unsigned short ODOMETER_PIN = 32;
      * unsigned long PULSES_PER_METER = 110;
+     * ArduinoRuntime arduino;
      *
-     * DirectionlessOdometer odometer(ODOMETER_PIN,
+     * DirectionlessOdometer odometer(arduino,
+     *                                ODOMETER_PIN,
      *                                []() { odometer.update(); },
      *                                PULSES_PER_METER);
      * \endcode
      */
-    DirectionlessOdometer(uint8_t pulsePin,
+    DirectionlessOdometer(Runtime& runtime,
+                          uint8_t pulsePin,
                           InterruptCallback callback,
-                          unsigned long pulsesPerMeter,
-                          Runtime& runtime = arduinoRuntime);
-#else
-    DirectionlessOdometer(uint8_t pulsePin,
-                          InterruptCallback callback,
-                          unsigned long pulsesPerMeter,
-                          Runtime& runtime);
-#endif
+                          unsigned long pulsesPerMeter);
 
     virtual ~DirectionlessOdometer() = default;
 

--- a/test/ut/BrushedMotor_test.cpp
+++ b/test/ut/BrushedMotor_test.cpp
@@ -29,7 +29,7 @@ public:
         EXPECT_CALL(mRuntime, getHighState()).WillOnce(Return(kHigh));
 
         mBrushedMotor
-            = std::make_unique<BrushedMotor>(kForwardPin, kBackwardPin, kEnablePin, mRuntime);
+            = std::make_unique<BrushedMotor>(mRuntime, kForwardPin, kBackwardPin, kEnablePin);
     }
 
     NiceMock<MockRuntime> mRuntime;
@@ -45,7 +45,7 @@ TEST(BrushedMotorHelperConstructorTest,
     EXPECT_CALL(runtime, getHighState()).WillOnce(Return(kHigh));
 
     BrushedMotorPins pins{ kForwardPin, kBackwardPin, kEnablePin };
-    BrushedMotor motor{ pins, runtime };
+    BrushedMotor motor{ runtime, pins };
 }
 
 TEST_F(BrushedMotorTest, setSpeed_WhenNotAttached_WillAttach)

--- a/test/ut/DirectionalOdometer_test.cpp
+++ b/test/ut/DirectionalOdometer_test.cpp
@@ -23,7 +23,7 @@ public:
     {
         ON_CALL(mRuntime, getLowState()).WillByDefault(Return(kPinStateWhenForward));
         mDirectionalOdometer = std::make_unique<DirectionalOdometer>(
-            kPin, kDirectionPin, kDummyCallback, kDefaultPulsesPerMeter, mRuntime);
+            mRuntime, kPin, kDirectionPin, kDummyCallback, kDefaultPulsesPerMeter);
     }
 
     NiceMock<MockRuntime> mRuntime;
@@ -54,7 +54,7 @@ public:
     {
         EXPECT_CALL(mRuntime, pinToInterrupt(_)).Times(2).WillRepeatedly(Return(kNotAnInterrupt));
         mDirectionalOdometer = std::make_unique<DirectionalOdometer>(
-            kPin, kDirectionPin, kDummyCallback, kDefaultPulsesPerMeter, mRuntime);
+            mRuntime, kPin, kDirectionPin, kDummyCallback, kDefaultPulsesPerMeter);
     }
 
     NiceMock<MockRuntime> mRuntime;
@@ -69,7 +69,7 @@ TEST(DirectionalOdometerConstructorTest, constructor_WhenCalled_WillSetDirection
     EXPECT_CALL(runtime, setPinDirection(_, inputState)).Times(AtLeast(1));
     EXPECT_CALL(runtime, setPinDirection(kDirectionPin, inputState));
     DirectionalOdometer directionalOdometer{
-        kPin, kDirectionPin, kDummyCallback, kDefaultPulsesPerMeter, runtime
+        runtime, kPin, kDirectionPin, kDummyCallback, kDefaultPulsesPerMeter
     };
 }
 
@@ -83,7 +83,7 @@ TEST(DirectionalOdometerConstructorTest,
     EXPECT_CALL(runtime, setPinDirection(kDirectionPin, inputState));
     DirectionalOdometerPins pins{ kPin, kDirectionPin };
     DirectionalOdometer directionalOdometer{
-        pins, kDummyCallback, kDefaultPulsesPerMeter, runtime
+        runtime, pins, kDummyCallback, kDefaultPulsesPerMeter
     };
 }
 

--- a/test/ut/DirectionlessOdometer_test.cpp
+++ b/test/ut/DirectionlessOdometer_test.cpp
@@ -39,7 +39,7 @@ public:
     {
         EXPECT_CALL(mRuntime, pinToInterrupt(kPin)).Times(2).WillRepeatedly(Return(kAnInterrupt));
         mDirectionlessOdometer = std::make_unique<DirectionlessOdometer>(
-            kPin, kDummyCallback, kDefaultPulsesPerMeter, mRuntime);
+            mRuntime, kPin, kDummyCallback, kDefaultPulsesPerMeter);
     }
 
     const unsigned long kPulsesPerMeter;
@@ -54,7 +54,7 @@ public:
     {
         EXPECT_CALL(mRuntime, pinToInterrupt(_)).Times(2).WillRepeatedly(Return(kNotAnInterrupt));
         mDirectionlessOdometer = std::make_unique<DirectionlessOdometer>(
-            kPin, kDummyCallback, kDefaultPulsesPerMeter, mRuntime);
+            mRuntime, kPin, kDummyCallback, kDefaultPulsesPerMeter);
     }
 
     NiceMock<MockRuntime> mRuntime;
@@ -71,7 +71,7 @@ TEST_F(DirectionlessOdometerConstructorTest, constructor_WhenCalled_WillSetInter
     EXPECT_CALL(mRuntime, getRisingEdgeMode()).WillOnce(Return(risingEdge));
     EXPECT_CALL(mRuntime, setPinDirection(kPin, inputState));
     EXPECT_CALL(mRuntime, setInterrupt(interruptPin, _, risingEdge));
-    DirectionlessOdometer odometer(kPin, kDummyCallback, kDefaultPulsesPerMeter, mRuntime);
+    DirectionlessOdometer odometer(mRuntime, kPin, kDummyCallback, kDefaultPulsesPerMeter);
 }
 
 TEST_F(DirectionlessOdometerConstructorTest, constructor_WhenCalled_WillPassCorrectInterrupt)
@@ -80,7 +80,7 @@ TEST_F(DirectionlessOdometerConstructorTest, constructor_WhenCalled_WillPassCorr
     EXPECT_CALL(odometerUser, update());
     EXPECT_CALL(mRuntime, setInterrupt(_, _, _)).WillOnce(InvokeArgument<1>());
     DirectionlessOdometer odometer(
-        kPin, []() { odometerUser.update(); }, kDefaultPulsesPerMeter, mRuntime);
+        mRuntime, kPin, []() { odometerUser.update(); }, kDefaultPulsesPerMeter);
 }
 
 TEST(DirectionlessOdometerBadPulsesPerMeter,
@@ -90,7 +90,7 @@ TEST(DirectionlessOdometerBadPulsesPerMeter,
     // to crash due to a division by zero
     NiceMock<MockRuntime> mRuntime;
     const auto badPulsesPerMeter = 0;
-    EXPECT_NO_THROW(DirectionlessOdometer(kPin, kDummyCallback, badPulsesPerMeter, mRuntime));
+    EXPECT_NO_THROW(DirectionlessOdometer(mRuntime, kPin, kDummyCallback, badPulsesPerMeter));
 }
 
 TEST_F(DirectionlessOdometerBasicTest, getDistance_WhenCalled_WillReturnCorrectDistance)

--- a/test/ut/DistanceCar_test.cpp
+++ b/test/ut/DistanceCar_test.cpp
@@ -15,26 +15,16 @@ using namespace smartcarlib::constants::car;
 class DistanceCarTest : public Test
 {
 public:
-    DistanceCarTest()
-        : mDistanceCar{ mControl, mOdometerLeft, mOdometerRight, mRuntime }
-    {
-    }
-
     NiceMock<MockControl> mControl;
     NiceMock<MockOdometer> mOdometerLeft;
     NiceMock<MockOdometer> mOdometerRight;
     NiceMock<MockRuntime> mRuntime;
-    DistanceCar mDistanceCar;
+    DistanceCar mDistanceCar{ mRuntime, mControl, mOdometerLeft, mOdometerRight };
 };
 
 class DistanceCarSingleOdometerTest : public Test
 {
 public:
-    DistanceCarSingleOdometerTest()
-        : mDistanceCar{ mControl, mOdometer, mRuntime }
-    {
-    }
-
     virtual void SetUp()
     {
         ON_CALL(mOdometer, isAttached()).WillByDefault(Return(true));
@@ -43,7 +33,7 @@ public:
     NiceMock<MockControl> mControl;
     NiceMock<MockOdometer> mOdometer;
     NiceMock<MockRuntime> mRuntime;
-    DistanceCar mDistanceCar;
+    DistanceCar mDistanceCar{ mRuntime, mControl, mOdometer };
 };
 
 class DistanceCarOdometersAttachedTest : public DistanceCarTest
@@ -102,7 +92,7 @@ TEST_F(DistanceCarTest, getDistance_WhenOneOdometerAttached_WillReturnItsDistanc
     EXPECT_CALL(mOdometerLeft, isAttached()).Times(2).WillRepeatedly(Return(true));
     EXPECT_CALL(mOdometerLeft, getDistance()).Times(2).WillRepeatedly(Return(leftOdometerDistance));
 
-    DistanceCar distanceCar(mControl, mOdometerLeft, mOdometerLeft, mRuntime);
+    DistanceCar distanceCar(mRuntime, mControl, mOdometerLeft, mOdometerLeft);
     EXPECT_EQ(distanceCar.getDistance(), leftOdometerDistance);
 }
 

--- a/test/ut/GY50_test.cpp
+++ b/test/ut/GY50_test.cpp
@@ -17,7 +17,7 @@ class GY50BasicTest : public Test
 public:
     GY50BasicTest(int offset             = kOffset,
                   unsigned long interval = smartcarlib::constants::gy50::kDefaultSamplingInterval)
-        : mGyro{ offset, interval, mRuntime }
+        : mGyro{ mRuntime, offset, interval }
         , kInterval{ interval }
     {
     }

--- a/test/ut/SR04_test.cpp
+++ b/test/ut/SR04_test.cpp
@@ -33,7 +33,7 @@ public:
         EXPECT_CALL(mRuntime, getLowState()).WillOnce(Return(kLow));
         EXPECT_CALL(mRuntime, getHighState()).WillOnce(Return(kHigh));
 
-        mSR04 = std::make_unique<SR04>(kTriggerPin, kEchoPin, maxDistance, mRuntime);
+        mSR04 = std::make_unique<SR04>(mRuntime, kTriggerPin, kEchoPin, maxDistance);
     }
 
     NiceMock<MockRuntime> mRuntime;

--- a/test/ut/SRF08_test.cpp
+++ b/test/ut/SRF08_test.cpp
@@ -24,7 +24,7 @@ class SRF08Test : public Test
 {
 public:
     SRF08Test()
-        : mSRF08{ kAddress, mRuntime }
+        : mSRF08{ mRuntime, kAddress }
     {
     }
 

--- a/test/ut/SharpSensors_test.cpp
+++ b/test/ut/SharpSensors_test.cpp
@@ -16,13 +16,8 @@ const uint8_t kPin = 5;
 class GP2D120Test : public Test
 {
 public:
-    GP2D120Test()
-        : mGP2D120{ kPin, mRuntime }
-    {
-    }
-
     NiceMock<MockRuntime> mRuntime;
-    GP2D120 mGP2D120;
+    GP2D120 mGP2D120{ mRuntime, kPin };
 };
 
 TEST_F(GP2D120Test, getDistance_WhenReadingTooLow_WillReturnZero)
@@ -52,13 +47,8 @@ TEST_F(GP2D120Test, getDistance_WhenReadingWithinRange_WillReturnCorrectResult)
 class GP2Y0A02Test : public Test
 {
 public:
-    GP2Y0A02Test()
-        : mGP2Y0A02{ kPin, mRuntime }
-    {
-    }
-
     NiceMock<MockRuntime> mRuntime;
-    GP2Y0A02 mGP2Y0A02;
+    GP2Y0A02 mGP2Y0A02{ mRuntime, kPin };
 };
 
 TEST_F(GP2Y0A02Test, getDistance_WhenReadingTooLow_WillReturnZero)
@@ -88,13 +78,8 @@ TEST_F(GP2Y0A02Test, getDistance_WhenReadingWithinRange_WillReturnCorrectResult)
 class GP2Y0A21Test : public Test
 {
 public:
-    GP2Y0A21Test()
-        : mGP2Y0A21{ kPin, mRuntime }
-    {
-    }
-
     NiceMock<MockRuntime> mRuntime;
-    GP2Y0A21 mGP2Y0A21;
+    GP2Y0A21 mGP2Y0A21{ mRuntime, kPin };
 };
 
 TEST_F(GP2Y0A21Test, getDistance_WhenReadingTooLow_WillReturnZero)

--- a/test/ut/SmartCar_test.cpp
+++ b/test/ut/SmartCar_test.cpp
@@ -12,32 +12,22 @@ using namespace ::testing;
 class SmartCarTest : public Test
 {
 public:
-    SmartCarTest()
-        : mSmartCar{ mControl, mHeadingSensor, mOdometerLeft, mOdometerRight, mRuntime }
-    {
-    }
-
     NiceMock<MockControl> mControl;
     NiceMock<MockHeadingSensor> mHeadingSensor;
     NiceMock<MockOdometer> mOdometerLeft;
     NiceMock<MockOdometer> mOdometerRight;
     NiceMock<MockRuntime> mRuntime;
-    SmartCar mSmartCar;
+    SmartCar mSmartCar{ mRuntime, mControl, mHeadingSensor, mOdometerLeft, mOdometerRight };
 };
 
 class SmartCarOneOdometerTest : public Test
 {
 public:
-    SmartCarOneOdometerTest()
-        : mSmartCar{ mControl, mHeadingSensor, mOdometer, mRuntime }
-    {
-    }
-
     NiceMock<MockControl> mControl;
     NiceMock<MockHeadingSensor> mHeadingSensor;
     NiceMock<MockOdometer> mOdometer;
     NiceMock<MockRuntime> mRuntime;
-    SmartCar mSmartCar;
+    SmartCar mSmartCar{ mRuntime, mControl, mHeadingSensor, mOdometer };
 };
 
 TEST_F(SmartCarTest, update_WhenCalled_WillUpdateHeadingAndSpeed)


### PR DESCRIPTION
## Description
The ArduinoRuntime was thus far injected by default in all
classes that needed it. This was achieved with a small 'hack'
which is now removed, in the name of consistency and object
orientation. This will also make it slightly simpler to move
to other platforms.

As a consequence, this is a backwards incompatible change.

## Solved issue(s)
Fixes #21 