### PR TITLE
Set motors to idle when speed is 0

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Smartcar shield
-version=7.0.0
+version=7.0.1
 author=Dimitris Platis
 maintainer=Dimitris Platis <dimitris@plat.is>
 sentence=Arduino library for controlling the Smartcar platform

--- a/src/motor/analog/pwm/BrushedMotor.cpp
+++ b/src/motor/analog/pwm/BrushedMotor.cpp
@@ -42,10 +42,16 @@ void BrushedMotor::setSpeed(int speed)
         mRuntime.setPinState(kForwardPin, kLow);
         mRuntime.setPinState(kBackwardPin, kHigh);
     }
-    else
+    else if (speed > 0)
     {
         // Set forward direction
         mRuntime.setPinState(kForwardPin, kHigh);
+        mRuntime.setPinState(kBackwardPin, kLow);
+    }
+    else
+    {
+        // Set idle
+        mRuntime.setPinState(kForwardPin, kLow);
         mRuntime.setPinState(kBackwardPin, kLow);
     }
 

--- a/test/ut/BrushedMotor_test.cpp
+++ b/test/ut/BrushedMotor_test.cpp
@@ -73,6 +73,14 @@ TEST_F(BrushedMotorTest, setSpeed_WhenPositiveSpeed_WillSetDirectionForward)
     mBrushedMotor->setSpeed(50);
 }
 
+TEST_F(BrushedMotorTest, setSpeed_WhenZeroSpeed_WillSetMotorsToIdle)
+{
+    EXPECT_CALL(mRuntime, setPinState(kForwardPin, kLow));
+    EXPECT_CALL(mRuntime, setPinState(kBackwardPin, kLow));
+
+    mBrushedMotor->setSpeed(0);
+}
+
 TEST_F(BrushedMotorTest, setSpeed_WhenSpeedOverBounds_WillSetMaxSpeedForward)
 {
     EXPECT_CALL(mRuntime, setPinState(kForwardPin, kHigh));


### PR DESCRIPTION
## Description
This will allow the motors to handle cases where no PWM pin is
specified and the motor driver's enable pin is directly wired to VCC

## Solved issue(s)
N/A