### PR TITLE
BrushedMotor-class-typo

### DIFF
--- a/src/motor/analog/pwm/BrushedMotor.hpp
+++ b/src/motor/analog/pwm/BrushedMotor.hpp
@@ -23,7 +23,7 @@ struct BrushedMotorPins
      * @brief Construct a BrushedMotorPins object
      *
      * @param forwardPin  The direction pin that when set to HIGH makes the motor spin forward
-     * @param backwardPin The direction pin that when set to HIGH makes the motor spin forward
+     * @param backwardPin The direction pin that when set to HIGH makes the motor spin backward
      * @param enablePin   The pin  that controls the motor's speed
      */
     BrushedMotorPins(uint8_t forwardPin, uint8_t backwardPin, uint8_t enablePin)


### PR DESCRIPTION
## Description
A typo at line 26 "spin forward" replaced with "spin backward"
## Solved issue(s)
