### PR TITLE
Fix failing gmock compilation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ enable_testing()
 
 # GTest and GMock do not play nicely with these flags, so disable them
 target_compile_options(gtest PRIVATE -Wno-sign-promo -Wno-pedantic)
+target_compile_options(gmock PRIVATE -Wno-conversion -Wno-pedantic)
 
 # Utility functions
 function(configure_test testExecutable)


### PR DESCRIPTION

## Description
Adapt warning flags to let `gmock` compile on the testsuite CI runner

## Solved issue(s)
Quick fix for #52 

### Note

This is definitely a quick fix, and really that `test/CMakeLists.txt` file could use some more modern CMake practices (e.g. not manipulate global CMake variables affecting all subsequently declared targets) to completely avoid having to work around clashes between project warning flags and the third-party test framework.

If the maintainer would like such a refactor to be PR'd instead/additionally, let me know.