### PR TITLE
Fix compilation on windows SMCE

### DIFF
--- a/examples/Car/DistanceCar/DistanceCar.ino
+++ b/examples/Car/DistanceCar/DistanceCar.ino
@@ -7,16 +7,14 @@ DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
-DirectionlessOdometer leftOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::leftOdometerPin,
-    []() { leftOdometer.update(); },
-    pulsesPerMeter);
-DirectionlessOdometer rightOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::rightOdometerPin,
-    []() { rightOdometer.update(); },
-    pulsesPerMeter);
+DirectionlessOdometer leftOdometer{ arduinoRuntime,
+                                    smartcarlib::pins::v2::leftOdometerPin,
+                                    []() { leftOdometer.update(); },
+                                    pulsesPerMeter };
+DirectionlessOdometer rightOdometer{ arduinoRuntime,
+                                     smartcarlib::pins::v2::rightOdometerPin,
+                                     []() { rightOdometer.update(); },
+                                     pulsesPerMeter };
 
 DistanceCar car(arduinoRuntime, control, leftOdometer, rightOdometer);
 

--- a/examples/Car/FullSerialControl/FullSerialControl.ino
+++ b/examples/Car/FullSerialControl/FullSerialControl.ino
@@ -7,17 +7,6 @@ DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);
 
-void setup()
-{
-    Serial.begin(9600);
-    Serial.setTimeout(200);
-}
-
-void loop()
-{
-    handleInput();
-}
-
 void handleInput()
 {
     // handle serial input if there is any
@@ -35,4 +24,15 @@ void handleInput()
             car.setAngle(deg);
         }
     }
+}
+
+void setup()
+{
+    Serial.begin(9600);
+    Serial.setTimeout(200);
+}
+
+void loop()
+{
+    handleInput();
 }

--- a/examples/Car/PidControllerMonitor/PidControllerMonitor.ino
+++ b/examples/Car/PidControllerMonitor/PidControllerMonitor.ino
@@ -16,16 +16,14 @@ DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
-DirectionlessOdometer leftOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::leftOdometerPin,
-    []() { leftOdometer.update(); },
-    pulsesPerMeter);
-DirectionlessOdometer rightOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::rightOdometerPin,
-    []() { rightOdometer.update(); },
-    pulsesPerMeter);
+DirectionlessOdometer leftOdometer{ arduinoRuntime,
+                                    smartcarlib::pins::v2::leftOdometerPin,
+                                    []() { leftOdometer.update(); },
+                                    pulsesPerMeter };
+DirectionlessOdometer rightOdometer{ arduinoRuntime,
+                                     smartcarlib::pins::v2::rightOdometerPin,
+                                     []() { rightOdometer.update(); },
+                                     pulsesPerMeter };
 
 DistanceCar car(arduinoRuntime, control, leftOdometer, rightOdometer);
 
@@ -42,10 +40,10 @@ void loop()
     car.update();
     if (millis() > previousPrintOut + PRINTOUT_INTERVAL)
     {
-        Serial.print(carSpeed); // print the controllers set point (the speed set to the car, i.e.
-                                // during setup())
-        Serial.print(","); // print a comma, in order to be easily parsed by the Serial Plotter or
-                           // other program
+        Serial.print(carSpeed); // print the controllers set point (the speed set to the car,
+                                // i.e. during setup())
+        Serial.print(",");      // print a comma, in order to be easily parsed by the Serial Plotter
+                                // or other program
         Serial.println(car.getSpeed()); // get the average speed of the two odometers
         previousPrintOut = millis();    // update the previous print out moment
     }

--- a/examples/Car/SerialControlServoESC/SerialControlServoESC.ino
+++ b/examples/Car/SerialControlServoESC/SerialControlServoESC.ino
@@ -1,7 +1,7 @@
 #include <Smartcar.h>
 
 const int SERVO_PIN = 8;
-const int ESC_PIN = 9;
+const int ESC_PIN   = 9;
 
 ServoMotor steering(SERVO_PIN);
 ServoMotor throttling(ESC_PIN);
@@ -9,24 +9,31 @@ AckermanControl control(steering, throttling);
 
 SimpleCar car(control);
 
-void setup() {
-  Serial.begin(9600);
-  Serial.setTimeout(100);
-}
-
-void loop() {
-  handleInput();
-}
-
-void handleInput() { // Handle serial input if there is any
-  if (Serial.available()) {
-    String input = Serial.readStringUntil('\n');
-    if (input.startsWith("m")) {
-      int throttle = input.substring(1).toInt();
-      car.setSpeed(throttle);
-    } else if (input.startsWith("t")) {
-      int deg = input.substring(1).toInt();
-      car.setAngle(deg);
+void handleInput()
+{ // Handle serial input if there is any
+    if (Serial.available())
+    {
+        String input = Serial.readStringUntil('\n');
+        if (input.startsWith("m"))
+        {
+            int throttle = input.substring(1).toInt();
+            car.setSpeed(throttle);
+        }
+        else if (input.startsWith("t"))
+        {
+            int deg = input.substring(1).toInt();
+            car.setAngle(deg);
+        }
     }
-  }
+}
+
+void setup()
+{
+    Serial.begin(9600);
+    Serial.setTimeout(100);
+}
+
+void loop()
+{
+    handleInput();
 }

--- a/examples/Car/SmartCar/SmartCar.ino
+++ b/examples/Car/SmartCar/SmartCar.ino
@@ -12,16 +12,14 @@ GY50 gyroscope(arduinoRuntime, 37);
 
 const auto pulsesPerMeter = 600;
 
-DirectionlessOdometer leftOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::leftOdometerPin,
-    []() { leftOdometer.update(); },
-    pulsesPerMeter);
-DirectionlessOdometer rightOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::rightOdometerPin,
-    []() { rightOdometer.update(); },
-    pulsesPerMeter);
+DirectionlessOdometer leftOdometer{ arduinoRuntime,
+                                    smartcarlib::pins::v2::leftOdometerPin,
+                                    []() { leftOdometer.update(); },
+                                    pulsesPerMeter };
+DirectionlessOdometer rightOdometer{ arduinoRuntime,
+                                     smartcarlib::pins::v2::rightOdometerPin,
+                                     []() { rightOdometer.update(); },
+                                     pulsesPerMeter };
 
 SmartCar car(arduinoRuntime, control, gyroscope, leftOdometer, rightOdometer);
 

--- a/examples/Car/automatedMovements/automatedMovements.ino
+++ b/examples/Car/automatedMovements/automatedMovements.ino
@@ -26,29 +26,6 @@ DirectionlessOdometer rightOdometer(
 
 SmartCar car(arduinoRuntime, control, gyroscope, leftOdometer, rightOdometer);
 
-void setup()
-{
-    car.enableCruiseControl();
-
-    // Travel around an imaginary square
-    go(distanceToTravel, carSpeed);
-    rotate(degreesToTurn, carSpeed);
-
-    go(distanceToTravel, carSpeed);
-    rotate(degreesToTurn, carSpeed);
-
-    go(distanceToTravel, carSpeed);
-    rotate(degreesToTurn, carSpeed);
-
-    go(distanceToTravel, carSpeed);
-    rotate(degreesToTurn, carSpeed);
-}
-
-void loop()
-{
-    // put your main code here, to run repeatedly:
-}
-
 /**
    Rotate the car at the specified degrees with the certain speed
    @param degrees   The degrees to turn. Positive values for clockwise
@@ -135,4 +112,27 @@ void go(long centimeters, float speed)
             = travelledDistance >= smartcarlib::utils::getAbsolute(centimeters);
     }
     car.setSpeed(0);
+}
+
+void setup()
+{
+    car.enableCruiseControl();
+
+    // Travel around an imaginary square
+    go(distanceToTravel, carSpeed);
+    rotate(degreesToTurn, carSpeed);
+
+    go(distanceToTravel, carSpeed);
+    rotate(degreesToTurn, carSpeed);
+
+    go(distanceToTravel, carSpeed);
+    rotate(degreesToTurn, carSpeed);
+
+    go(distanceToTravel, carSpeed);
+    rotate(degreesToTurn, carSpeed);
+}
+
+void loop()
+{
+    // put your main code here, to run repeatedly:
 }

--- a/examples/Car/automatedMovements/automatedMovements.ino
+++ b/examples/Car/automatedMovements/automatedMovements.ino
@@ -13,16 +13,14 @@ GY50 gyroscope(arduinoRuntime, 37);
 
 const auto pulsesPerMeter = 600;
 
-DirectionlessOdometer leftOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::leftOdometerPin,
-    []() { leftOdometer.update(); },
-    pulsesPerMeter);
-DirectionlessOdometer rightOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::rightOdometerPin,
-    []() { rightOdometer.update(); },
-    pulsesPerMeter);
+DirectionlessOdometer leftOdometer{ arduinoRuntime,
+                                    smartcarlib::pins::v2::leftOdometerPin,
+                                    []() { leftOdometer.update(); },
+                                    pulsesPerMeter };
+DirectionlessOdometer rightOdometer{ arduinoRuntime,
+                                     smartcarlib::pins::v2::rightOdometerPin,
+                                     []() { rightOdometer.update(); },
+                                     pulsesPerMeter };
 
 SmartCar car(arduinoRuntime, control, gyroscope, leftOdometer, rightOdometer);
 
@@ -60,20 +58,21 @@ void rotate(int degrees, float speed)
         if (degrees < 0 && currentHeading > initialHeading)
         {
             // If we are turning left and the current heading is larger than the
-            // initial one (e.g. started at 10 degrees and now we are at 350), we need to substract
-            // 360 so to eventually get a signed displacement from the initial heading (-20)
+            // initial one (e.g. started at 10 degrees and now we are at 350), we need to
+            // substract 360 so to eventually get a signed displacement from the initial heading
+            // (-20)
             currentHeading -= 360;
         }
         else if (degrees > 0 && currentHeading < initialHeading)
         {
             // If we are turning right and the heading is smaller than the
-            // initial one (e.g. started at 350 degrees and now we are at 20), so to get a signed
-            // displacement (+30)
+            // initial one (e.g. started at 350 degrees and now we are at 20), so to get a
+            // signed displacement (+30)
             currentHeading += 360;
         }
         // Degrees turned so far is initial heading minus current (initial heading
-        // is at least 0 and at most 360. To handle the "edge" cases we substracted or added 360 to
-        // currentHeading)
+        // is at least 0 and at most 360. To handle the "edge" cases we substracted or added 360
+        // to currentHeading)
         int degreesTurnedSoFar  = initialHeading - currentHeading;
         hasReachedTargetDegrees = smartcarlib::utils::getAbsolute(degreesTurnedSoFar)
                                   >= smartcarlib::utils::getAbsolute(degrees);

--- a/examples/Car/manualControl/manualControl.ino
+++ b/examples/Car/manualControl/manualControl.ino
@@ -12,16 +12,6 @@ DifferentialControl control(leftMotor, rightMotor);
 
 SimpleCar car(control);
 
-void setup()
-{
-    Serial.begin(9600);
-}
-
-void loop()
-{
-    handleInput();
-}
-
 void handleInput()
 { // handle serial input if there is any
     if (Serial.available())
@@ -51,4 +41,14 @@ void handleInput()
             car.setAngle(0);
         }
     }
+}
+
+void setup()
+{
+    Serial.begin(9600);
+}
+
+void loop()
+{
+    handleInput();
 }

--- a/examples/Car/manualWithCruiseControl/manualWithCruiseControl.ino
+++ b/examples/Car/manualWithCruiseControl/manualWithCruiseControl.ino
@@ -25,19 +25,6 @@ DirectionlessOdometer rightOdometer(
 
 DistanceCar car(arduinoRuntime, control, leftOdometer, rightOdometer);
 
-void setup()
-{
-    Serial.begin(9600);
-
-    car.enableCruiseControl(); // using default PID values
-}
-
-void loop()
-{
-    car.update();
-    handleInput();
-}
-
 void handleInput()
 { // handle serial input if there is any
     if (Serial.available())
@@ -67,4 +54,17 @@ void handleInput()
             car.setAngle(0);
         }
     }
+}
+
+void setup()
+{
+    Serial.begin(9600);
+
+    car.enableCruiseControl(); // using default PID values
+}
+
+void loop()
+{
+    car.update();
+    handleInput();
 }

--- a/examples/Car/manualWithCruiseControl/manualWithCruiseControl.ino
+++ b/examples/Car/manualWithCruiseControl/manualWithCruiseControl.ino
@@ -12,16 +12,14 @@ DifferentialControl control(leftMotor, rightMotor);
 
 const auto pulsesPerMeter = 600;
 
-DirectionlessOdometer leftOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::leftOdometerPin,
-    []() { leftOdometer.update(); },
-    pulsesPerMeter);
-DirectionlessOdometer rightOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::rightOdometerPin,
-    []() { rightOdometer.update(); },
-    pulsesPerMeter);
+DirectionlessOdometer leftOdometer{ arduinoRuntime,
+                                    smartcarlib::pins::v2::leftOdometerPin,
+                                    []() { leftOdometer.update(); },
+                                    pulsesPerMeter };
+DirectionlessOdometer rightOdometer{ arduinoRuntime,
+                                     smartcarlib::pins::v2::rightOdometerPin,
+                                     []() { rightOdometer.update(); },
+                                     pulsesPerMeter };
 
 DistanceCar car(arduinoRuntime, control, leftOdometer, rightOdometer);
 
@@ -29,8 +27,8 @@ void handleInput()
 { // handle serial input if there is any
     if (Serial.available())
     {
-        char input = Serial.read(); // read everything that has been received so far and log down
-                                    // the last entry
+        char input = Serial.read(); // read everything that has been received so far and log
+                                    // down the last entry
         switch (input)
         {
         case 'l': // rotate counter-clockwise going forward

--- a/examples/Car/rotateOnSpot/rotateOnSpot.ino
+++ b/examples/Car/rotateOnSpot/rotateOnSpot.ino
@@ -12,16 +12,6 @@ GY50 gyroscope(arduinoRuntime, GYROSCOPE_OFFSET);
 
 HeadingCar car(control, gyroscope);
 
-void setup()
-{
-    delay(1000);
-    rotateOnSpot(90, carSpeed); // rotate clockwise 90 degrees on spot
-    delay(1000);
-    rotateOnSpot(-90, carSpeed); // rotate counter clockwise 90 degrees on spot
-}
-
-void loop() {}
-
 /**
    Rotate the car on spot at the specified degrees with the certain speed
    @param degrees   The degrees to rotate on spot. Positive values for clockwise
@@ -73,3 +63,13 @@ void rotateOnSpot(int targetDegrees, int speed)
     }
     car.setSpeed(0); // we have reached the target, so stop the car
 }
+
+void setup()
+{
+    delay(1000);
+    rotateOnSpot(90, carSpeed); // rotate clockwise 90 degrees on spot
+    delay(1000);
+    rotateOnSpot(-90, carSpeed); // rotate counter clockwise 90 degrees on spot
+}
+
+void loop() {}

--- a/examples/sensors/odometer/directionalOdometers/directionalOdometers.ino
+++ b/examples/sensors/odometer/directionalOdometers/directionalOdometers.ino
@@ -4,16 +4,14 @@ const unsigned long LEFT_PULSES_PER_METER  = 600;
 const unsigned long RIGHT_PULSES_PER_METER = 740;
 
 ArduinoRuntime arduinoRuntime;
-DirectionalOdometer leftOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::leftOdometerPins,
-    []() { leftOdometer.update(); },
-    LEFT_PULSES_PER_METER);
-DirectionalOdometer rightOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::rightOdometerPins,
-    []() { rightOdometer.update(); },
-    RIGHT_PULSES_PER_METER);
+DirectionalOdometer leftOdometer{ arduinoRuntime,
+                                  smartcarlib::pins::v2::leftOdometerPins,
+                                  []() { leftOdometer.update(); },
+                                  LEFT_PULSES_PER_METER };
+DirectionalOdometer rightOdometer{ arduinoRuntime,
+                                   smartcarlib::pins::v2::rightOdometerPins,
+                                   []() { rightOdometer.update(); },
+                                   RIGHT_PULSES_PER_METER };
 
 void setup()
 {

--- a/examples/sensors/odometer/findPulsesPerMeter/findPulsesPerMeter.ino
+++ b/examples/sensors/odometer/findPulsesPerMeter/findPulsesPerMeter.ino
@@ -4,8 +4,9 @@ const unsigned short odometerPin   = 2;
 const unsigned long pulsesPerMeter = 100;
 
 ArduinoRuntime arduinoRuntime;
-DirectionlessOdometer odometer(
-    arduinoRuntime, odometerPin, []() { odometer.update(); }, pulsesPerMeter);
+DirectionlessOdometer odometer{
+    arduinoRuntime, odometerPin, []() { odometer.update(); }, pulsesPerMeter
+};
 
 void setup()
 {

--- a/examples/sensors/odometer/singleOdometer/singleOdometer.ino
+++ b/examples/sensors/odometer/singleOdometer/singleOdometer.ino
@@ -4,8 +4,9 @@ const unsigned short odometerPin   = 2;
 const unsigned long pulsesPerMeter = 400;
 
 ArduinoRuntime arduinoRuntime;
-DirectionlessOdometer odometer(
-    arduinoRuntime, odometerPin, []() { odometer.update(); }, pulsesPerMeter);
+DirectionlessOdometer odometer{
+    arduinoRuntime, odometerPin, []() { odometer.update(); }, pulsesPerMeter
+};
 
 void setup()
 {

--- a/examples/sensors/odometer/twoOdometers/twoOdometers.ino
+++ b/examples/sensors/odometer/twoOdometers/twoOdometers.ino
@@ -3,16 +3,14 @@
 const auto pulsesPerMeter = 600;
 
 ArduinoRuntime arduinoRuntime;
-DirectionlessOdometer leftOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::leftOdometerPin,
-    []() { leftOdometer.update(); },
-    pulsesPerMeter);
-DirectionlessOdometer rightOdometer(
-    arduinoRuntime,
-    smartcarlib::pins::v2::rightOdometerPin,
-    []() { rightOdometer.update(); },
-    pulsesPerMeter);
+DirectionlessOdometer leftOdometer{ arduinoRuntime,
+                                    smartcarlib::pins::v2::leftOdometerPin,
+                                    []() { leftOdometer.update(); },
+                                    pulsesPerMeter };
+DirectionlessOdometer rightOdometer{ arduinoRuntime,
+                                     smartcarlib::pins::v2::rightOdometerPin,
+                                     []() { rightOdometer.update(); },
+                                     pulsesPerMeter };
 
 void setup()
 {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Smartcar shield
-version=7.0.1
+version=7.0.2
 author=Dimitris Platis
 maintainer=Dimitris Platis <dimitris@plat.is>
 sentence=Arduino library for controlling the Smartcar platform

--- a/test/test_libs/CMakeLists.txt
+++ b/test/test_libs/CMakeLists.txt
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           release-1.11.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
## Description
This pull request intends to fix two issues when compiling with SMCE on Windows, while writing more idiomatic C++:
1. Functions in example sketches no longer declared _after_ their usage (which is OK in Arduino IDE due to its preprocessor)
2. Brace initialization used for Odometer constructors (Windows compiliers didn't like lambdas inside the parentheses-using constructor)

Unrelated to the above, some formatting took place.

## Solved issue(s)
N/A